### PR TITLE
http extensions - fix charset

### DIFF
--- a/extensions/http/src/jolie/net/HttpProtocol.java
+++ b/extensions/http/src/jolie/net/HttpProtocol.java
@@ -841,7 +841,7 @@ public class HttpProtocol extends CommProtocol
 		throws IOException
 	{
 		Method method = send_getRequestMethod( message );
-		String charset = HttpUtils.getCharset( getStringParameter( Parameters.CHARSET ), null );
+		String charset = HttpUtils.getCharset( getStringParameter( Parameters.CHARSET, "utf-8" ), null );
 		String format = send_getFormat();
 		EncodedContent encodedContent = send_encodeContent( message, method, charset, format );
 		StringBuilder headerBuilder = new StringBuilder();
@@ -1255,7 +1255,7 @@ public class HttpProtocol extends CommProtocol
 		throws IOException
 	{
 		HttpMessage message = new HttpParser( istream ).parse();
-		String charset = HttpUtils.getCharset( getStringParameter( Parameters.CHARSET ), message );
+		String charset = HttpUtils.getCharset( null, message );
 		CommMessage retVal = null;
 		DecodedMessage decodedMessage = new DecodedMessage();
 

--- a/extensions/http/src/jolie/net/http/HttpUtils.java
+++ b/extensions/http/src/jolie/net/http/HttpUtils.java
@@ -130,7 +130,7 @@ public class HttpUtils
 		if ( defaultCharset != null && !defaultCharset.isEmpty() ) {
 			return defaultCharset;
 		}
-		return "utf-8"; // Jolie's default charset which is today's standard
+		return "iso-8859-1"; // this follows RFC 2616 3.4.1 Missing Charset
 	}
 
 	public static ByteArray encode( String encoding, ByteArray content, StringBuilder headerBuilder ) throws IOException


### PR DESCRIPTION
- in the HTTP extension we have this "charset" parameter, which at the moment we enforce for outgoing messages (perfectly correct) but also for incoming ones if no other charset has been specified.
- The latter behaviour is in clear contradiction to HTTP's RFC (http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.4.1) which enforces the use of latin1 (iso-8859-1) in that case.
- I got across over this limitation only when setting our charset parameter testwise to "utf-16". The content gets delivered correctly, but webbrowsers like Firefox continue to send POST requests (form data in urlencoded) in URL-encoded ASCII (in theory also latin1 which is the superset).