### PR TITLE
http extensions - reconcile errorGenerator()

### DIFF
--- a/extensions/http/src/jolie/net/HttpProtocol.java
+++ b/extensions/http/src/jolie/net/HttpProtocol.java
@@ -89,7 +89,7 @@ import org.xml.sax.SAXException;
  * @author Fabrizio Montesi
  * 14 Nov 2012 - Saverio Giallorenzo - Fabrizio Montesi: support for status codes
  */
-public class HttpProtocol extends CommProtocol
+public class HttpProtocol extends CommProtocol implements HttpUtils.HttpProtocol
 {
 	private static final int DEFAULT_STATUS_CODE = 200;
 	private static final int DEFAULT_REDIRECTION_STATUS_CODE = 303;
@@ -806,7 +806,7 @@ public class HttpProtocol extends CommProtocol
 		}
 	}
 	
-	private void send_internal( OutputStream ostream, CommMessage message, InputStream istream )
+	public void send_internal( OutputStream ostream, CommMessage message, InputStream istream )
 		throws IOException
 	{
 		Method method = send_getRequestMethod( message );
@@ -838,14 +838,7 @@ public class HttpProtocol extends CommProtocol
 	public void send( OutputStream ostream, CommMessage message, InputStream istream )
 		throws IOException
 	{
-		try {
-			send_internal( ostream, message, istream );
-		} catch ( IOException e ) {
-			if ( inInputPort && channel().isOpen() ) {
-				HttpUtils.errorGenerator( ostream, e );
-			}
-			throw e;
-		}
+		HttpUtils.send( ostream, message, istream, inInputPort, channel(), this );
 	}
 
 	private void parseXML( HttpMessage message, Value value, String charset )
@@ -1221,7 +1214,7 @@ public class HttpProtocol extends CommProtocol
 		}
 	}
 	
-	private CommMessage recv_internal( InputStream istream, OutputStream ostream )
+	public CommMessage recv_internal( InputStream istream, OutputStream ostream )
 		throws IOException
 	{
 		HttpMessage message = new HttpParser( istream ).parse();
@@ -1336,14 +1329,7 @@ public class HttpProtocol extends CommProtocol
 	public CommMessage recv( InputStream istream, OutputStream ostream )
 		throws IOException
 	{
-		try {
-			return recv_internal( istream, ostream );
-		} catch ( IOException e ) {
-			if ( inInputPort && channel().isOpen() ) {
-				HttpUtils.errorGenerator( ostream, e );
-			}
-			throw e;
-		}
+		return HttpUtils.recv( istream, ostream, inInputPort, channel(), this );
 	}
 
 	private Type getSendType( CommMessage message )

--- a/extensions/soap/src/jolie/net/SoapProtocol.java
+++ b/extensions/soap/src/jolie/net/SoapProtocol.java
@@ -132,7 +132,7 @@ import org.xml.sax.InputSource;
  * documents.
  *
  */
-public class SoapProtocol extends SequentialCommProtocol {
+public class SoapProtocol extends SequentialCommProtocol implements HttpUtils.HttpProtocol {
 
     private String inputId = null;
     private final Interpreter interpreter;
@@ -649,7 +649,7 @@ public class SoapProtocol extends SequentialCommProtocol {
         }
     }
 
-    private void send_internal(OutputStream ostream, CommMessage message, InputStream istream)
+    public void send_internal(OutputStream ostream, CommMessage message, InputStream istream)
             throws IOException {
         try {
             inputId = message.operationName();
@@ -867,14 +867,7 @@ public class SoapProtocol extends SequentialCommProtocol {
 
     public void send(OutputStream ostream, CommMessage message, InputStream istream)
             throws IOException {
-        try {
-            send_internal(ostream, message, istream);
-        } catch (IOException e) {
-            if (inInputPort && channel().isOpen()) {
-                HttpUtils.errorGenerator(ostream, e);
-            }
-            throw e;
-        }
+        HttpUtils.send(ostream, message, istream, inInputPort, channel(), this);
     }
 
     private void xmlNodeToValue(Value value, Node node, boolean isRecRoot) {
@@ -946,7 +939,7 @@ public class SoapProtocol extends SequentialCommProtocol {
      * schemaFactory.newSchema( sources.toArray( new Source[sources.size()] ) );
      * } catch( SAXException e ) { throw new IOException( e ); } }
      */
-    private CommMessage recv_internal(InputStream istream, OutputStream ostream)
+    public CommMessage recv_internal(InputStream istream, OutputStream ostream)
             throws IOException {
         HttpParser parser = new HttpParser(istream);
         HttpMessage message = parser.parse();
@@ -1094,14 +1087,7 @@ public class SoapProtocol extends SequentialCommProtocol {
     public CommMessage recv(InputStream istream, OutputStream ostream)
         throws IOException
     {
-        try {
-            return recv_internal(istream, ostream);
-        } catch (IOException e) {
-            if (inInputPort && channel().isOpen()) {
-            	HttpUtils.errorGenerator(ostream, e);
-            }
-            throw e;
-        }
+        return HttpUtils.recv(istream, ostream, inInputPort, channel(), this);
     }
 
     private String recv_getResourcePath(HttpMessage message) {

--- a/extensions/xmlrpc/src/jolie/net/XmlRpcProtocol.java
+++ b/extensions/xmlrpc/src/jolie/net/XmlRpcProtocol.java
@@ -85,7 +85,7 @@ import org.w3c.dom.NodeList;
  * All the array in an input XMLRPC message will be translated into Jolie by means of arrays of the keyword array.
  * 
  */
-public class XmlRpcProtocol extends SequentialCommProtocol
+public class XmlRpcProtocol extends SequentialCommProtocol implements HttpUtils.HttpProtocol
 {
 	private String inputId = null;
 	final private Transformer transformer;
@@ -300,7 +300,7 @@ public class XmlRpcProtocol extends SequentialCommProtocol
 		}
 	}
 
-	private void send_internal( OutputStream ostream, CommMessage message, InputStream istream )
+	public void send_internal( OutputStream ostream, CommMessage message, InputStream istream )
 		throws IOException
 	{
 		Document doc = docBuilder.newDocument();
@@ -436,17 +436,10 @@ public class XmlRpcProtocol extends SequentialCommProtocol
 	public void send( OutputStream ostream, CommMessage message, InputStream istream )
 		throws IOException
 	{
-		try {
-			send_internal( ostream, message, istream );
-		} catch ( IOException e ) {
-			if ( inInputPort && channel().isOpen() ) {
-				HttpUtils.errorGenerator( ostream, e );
-			}
-			throw e;
-		}
+		HttpUtils.send( ostream, message, istream, inInputPort, channel(), this );
 	}
 
-	private CommMessage recv_internal( InputStream istream, OutputStream ostream )
+	public CommMessage recv_internal( InputStream istream, OutputStream ostream )
 		throws IOException
 	{
 		HttpParser parser = new HttpParser( istream );
@@ -523,13 +516,6 @@ public class XmlRpcProtocol extends SequentialCommProtocol
 	public CommMessage recv( InputStream istream, OutputStream ostream )
 		throws IOException
 	{
-		try {
-			return recv_internal( istream, ostream );
-		} catch ( IOException e ) {
-			if ( inInputPort && channel().isOpen() ) {
-				HttpUtils.errorGenerator( ostream, e );
-			}
-			throw e;
-		}
+		return HttpUtils.recv( istream, ostream, inInputPort, channel(), this );
 	}
 }


### PR DESCRIPTION
This refactoring moves its calls into HttpUtils and makes it much harder to introduce inconsistencies (future extensions).

Notice: on recv() we do need an explicit ostream.flush(), which on send() is done by Jolie. channel() is protected so
I could not directly add it in the interface.