### PR TITLE
Added Absolute path operations to File 

### DIFF
--- a/include/file.iol
+++ b/include/file.iol
@@ -81,14 +81,14 @@ RequestResponse:
 	 * Can be used to construct an absolute path for new files that does not exist yet.
 	 * Throws a InvalidPathException fault if input is a relative path is not system recognized path.
 	 */
-	toAbsolutePath( string )( string ) throws JavaExceptionType( InvalidPathExceptionType ),
+	toAbsolutePath( string )( string ) throws InvalidPathExceptionType( JavaExceptionType ),
 
 	/**!
 	 * Constructs the path to the parent directory. 
 	 * Can be used to construct paths that does not exist so long as the path uses the system's filesystem path conventions.
 	 * Throws a InvalidPathException fault if input path is not a recognized system path or if the parent has no parent.
 	 */
-	getParentPath( string )( string ) throws JavaExceptionType( InvalidPathExceptionType ),
+	getParentPath( string )( string ) throws InvalidPathExceptionType( JavaExceptionType ),
 
 	/**!
 	  it returns if a filename is a directory or not. False if the file does not exist.

--- a/include/file.iol
+++ b/include/file.iol
@@ -79,14 +79,16 @@ RequestResponse:
 	/**!
 	 * Constructs an absolute path to the target file or directory. 
 	 * Can be used to construct an absolute path for new files that does not exist yet.
+	 * Throws a fault if input is a relative path is not system recognized path.
 	 */
-	getAbsolutePath( string )( string ),
+	toAbsolutePath( string )( string ),
 
 	/**!
-	 * Constructs an absolute path to the parent directory of the target file or directory.
-	 * Can be used to construct an absolute path to the parent directory for files that does not exists yet.
+	 * Constructs the path to the parent directory. 
+	 * Can be used to construct paths that does not exist so long as the path uses the system's filesystem path conventions.
+	 * Throws a fault if input path is not a recognized system path or if the parent has no parent.
 	 */
-	getAbsoluteParentPath( string )( string ),
+	getParentPath( string )( string ),
 
 	/**!
 	  it returns if a filename is a directory or not. False if the file does not exist.

--- a/include/file.iol
+++ b/include/file.iol
@@ -77,14 +77,14 @@ type ListResponse:void {
 interface FileInterface {
 RequestResponse:
 	/**!
-	 * Constructs a absolute path to the target file or directory. 
-	 * Can be used to construct a absolute path for new files that does not exist yet.
+	 * Constructs an absolute path to the target file or directory. 
+	 * Can be used to construct an absolute path for new files that does not exist yet.
 	 */
 	getAbsolutePath( string )( string ),
 
 	/**!
-	 * Constructs a absolute path to the parent directory of the target file or directory.
-	 * Can be used to construct a absolute path to the parent directory for files that does not exists yet.
+	 * Constructs an absolute path to the parent directory of the target file or directory.
+	 * Can be used to construct an absolute path to the parent directory for files that does not exists yet.
 	 */
 	getAbsoluteParentPath( string )( string ),
 

--- a/include/file.iol
+++ b/include/file.iol
@@ -79,16 +79,16 @@ RequestResponse:
 	/**!
 	 * Constructs an absolute path to the target file or directory. 
 	 * Can be used to construct an absolute path for new files that does not exist yet.
-	 * Throws a fault if input is a relative path is not system recognized path.
+	 * Throws a InvalidPathException fault if input is a relative path is not system recognized path.
 	 */
-	toAbsolutePath( string )( string ),
+	toAbsolutePath( string )( string ) throws JavaExceptionType( InvalidPathExceptionType ),
 
 	/**!
 	 * Constructs the path to the parent directory. 
 	 * Can be used to construct paths that does not exist so long as the path uses the system's filesystem path conventions.
-	 * Throws a fault if input path is not a recognized system path or if the parent has no parent.
+	 * Throws a InvalidPathException fault if input path is not a recognized system path or if the parent has no parent.
 	 */
-	getParentPath( string )( string ),
+	getParentPath( string )( string ) throws JavaExceptionType( InvalidPathExceptionType ),
 
 	/**!
 	  it returns if a filename is a directory or not. False if the file does not exist.

--- a/include/file.iol
+++ b/include/file.iol
@@ -77,6 +77,18 @@ type ListResponse:void {
 interface FileInterface {
 RequestResponse:
 	/**!
+	 * Constructs a absolute path to the target file or directory. 
+	 * Can be used to construct a absolute path for new files that does not exist yet.
+	 */
+	getAbsolutePath( string )( string ),
+
+	/**!
+	 * Constructs a absolute path to the parent directory of the target file or directory.
+	 * Can be used to construct a absolute path to the parent directory for files that does not exists yet.
+	 */
+	getAbsoluteParentPath( string )( string ),
+
+	/**!
 	  it returns if a filename is a directory or not. False if the file does not exist.
 	*/
 	isDirectory( string )( bool ) throws FileNotFound(FileNotFoundType) IOException(IOExceptionType),
@@ -163,6 +175,7 @@ RequestResponse:
 	convertFromBinaryToBase64Value( raw )( string ),
 	/**! deprecated, please use base64ToRaw@Converter()() from converter.iol */
 	convertFromBase64ToBinaryValue( string )( raw ) throws IOException(IOExceptionType)
+
 }
 
 outputPort File {

--- a/include/file.iol
+++ b/include/file.iol
@@ -81,14 +81,14 @@ RequestResponse:
 	 * Can be used to construct an absolute path for new files that does not exist yet.
 	 * Throws a InvalidPathException fault if input is a relative path is not system recognized path.
 	 */
-	toAbsolutePath( string )( string ) throws InvalidPathExceptionType( JavaExceptionType ),
+	toAbsolutePath( string )( string ) throws InvalidPathException( JavaExceptionType ),
 
 	/**!
 	 * Constructs the path to the parent directory. 
 	 * Can be used to construct paths that does not exist so long as the path uses the system's filesystem path conventions.
 	 * Throws a InvalidPathException fault if input path is not a recognized system path or if the parent has no parent.
 	 */
-	getParentPath( string )( string ) throws InvalidPathExceptionType( JavaExceptionType ),
+	getParentPath( string )( string ) throws InvalidPathException( JavaExceptionType ),
 
 	/**!
 	  it returns if a filename is a directory or not. False if the file does not exist.

--- a/javaServices/coreJavaServices/src/joliex/io/FileService.java
+++ b/javaServices/coreJavaServices/src/joliex/io/FileService.java
@@ -747,20 +747,36 @@ public class FileService extends JavaService
 	}
 
 	@RequestResponse
-	public Value getAbsolutePath( Value request ) {
+	public Value toAbsolutePath( Value request ) throws FaultException
+	{
 		Value response = Value.create();
 		String fileName = request.strValue();
 		
-		response.setValue( Paths.get( fileName ).toAbsolutePath().toString() );
+		String absolutePath = Paths.get( fileName ).toAbsolutePath().normalize().toString();
+
+		if ( absolutePath == null ) {
+			throw new FaultException( "Not a valid path", new IOException() );
+		}
+
+		response.setValue( absolutePath );
 		return response;
 	}
 
-        @RequestResponse
-        public Value getAbsoluteParentPath( Value request ) {
-    	       Value response = Value.create();
-               String fileName = request.strValue();
+    @RequestResponse
+    public Value getParentPath( Value request ) throws FaultException
+    {
+        Value response = Value.create();
+        String fileName = request.strValue();
 
-               response.setValue( Paths.get( fileName ).toAbsolutePath().getParent().toString() );
-               return response;
+        String parentPath = Paths.get( fileName ).getParent().toString();
+
+        if ( parentPath == null ) {
+            throw new FaultException( "Path has no parent or is not a valid path", 
+                new IOException() );
         }
+
+        response.setValue( parentPath );
+
+        return response;
+    }
 }

--- a/javaServices/coreJavaServices/src/joliex/io/FileService.java
+++ b/javaServices/coreJavaServices/src/joliex/io/FileService.java
@@ -755,7 +755,7 @@ public class FileService extends JavaService
 		String absolutePath = Paths.get( fileName ).toAbsolutePath().normalize().toString();
 
 		if ( absolutePath == null ) {
-			throw new FaultException( "Not a valid path", new IOException() );
+			throw new FaultException( new IOException( "Not a valid path" ) );
 		}
 
 		response.setValue( absolutePath );
@@ -771,8 +771,7 @@ public class FileService extends JavaService
         String parentPath = Paths.get( fileName ).getParent().toString();
 
         if ( parentPath == null ) {
-            throw new FaultException( "Path has no parent or is not a valid path", 
-                new IOException() );
+            throw new FaultException( new IOException( "Path has no parent or is not a valid path" ) );
         }
 
         response.setValue( parentPath );

--- a/javaServices/coreJavaServices/src/joliex/io/FileService.java
+++ b/javaServices/coreJavaServices/src/joliex/io/FileService.java
@@ -744,4 +744,24 @@ public class FileService extends JavaService
 			return pattern.matcher( filename ).matches() && (!dirsOnly || file.isDirectory());
 		}
 	}
+
+	@RequestResponse
+    public Value getAbsolutePath( Value request ) {
+        Value response = Value.create();
+        String fileName = request.strValue();
+
+        response.setValue(Paths.get(fileName).toAbsolutePath().toString());
+
+        return response;
+    }
+
+    @RequestResponse
+    public Value getAbsoluteParentPath( Value request ) {
+        Value response = Value.create();
+        String fileName = request.strValue();
+
+        response.setValue(Paths.get(fileName).toAbsolutePath().getParent().toString());
+
+        return response;
+    }
 }

--- a/javaServices/coreJavaServices/src/joliex/io/FileService.java
+++ b/javaServices/coreJavaServices/src/joliex/io/FileService.java
@@ -40,6 +40,8 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
+import java.nio.file.Path;
+import java.nio.file.InvalidPathException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Enumeration;
@@ -751,31 +753,40 @@ public class FileService extends JavaService
 	{
 		Value response = Value.create();
 		String fileName = request.strValue();
-		
-		String absolutePath = Paths.get( fileName ).toAbsolutePath().normalize().toString();
 
-		if ( absolutePath == null ) {
-			throw new FaultException( new IOException( "Not a valid path" ) );
+		Path absolutePath = null;
+		
+		try {
+			absolutePath = Paths.get( fileName ).toAbsolutePath().normalize();
+		} catch ( InvalidPathException invalidPathException ) {
+			throw new FaultException( invalidPathException );
 		}
 
-		response.setValue( absolutePath );
+		response.setValue( absolutePath.toString() );
+
 		return response;
 	}
 
-    @RequestResponse
-    public Value getParentPath( Value request ) throws FaultException
-    {
-        Value response = Value.create();
-        String fileName = request.strValue();
+	@RequestResponse
+	public Value getParentPath( Value request ) throws FaultException
+	{
+		Value response = Value.create();
+		String fileName = request.strValue();
 
-        String parentPath = Paths.get( fileName ).getParent().toString();
+		Path parent = null;
 
-        if ( parentPath == null ) {
-            throw new FaultException( new IOException( "Path has no parent or is not a valid path" ) );
-        }
+		try {
+			parent = Paths.get( fileName ).getParent();
+		} catch ( InvalidPathException invalidPathException ) {
+			throw new FaultException( invalidPathException );
+		}
 
-        response.setValue( parentPath );
+		if ( parent == null ) {
+			throw new FaultException( new InvalidPathException( fileName, "Path has no parent" ) );
+		}
+		
+		response.setValue( parent.toString() );
 
-        return response;
-    }
+		return response;
+	}
 }

--- a/javaServices/coreJavaServices/src/joliex/io/FileService.java
+++ b/javaServices/coreJavaServices/src/joliex/io/FileService.java
@@ -39,6 +39,7 @@ import java.io.Writer;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Enumeration;


### PR DESCRIPTION
The motivation for this enhancement is to provide operations in the File interface to convert relative file paths into absolute file paths, using the Java 7 `Path` class.

The operations does not check whether the files exists (this is a task for the user if they want to), so they can be used to create new file paths for files that does not exist.