### PR TITLE
Renaming MatchRequest to avoid conflict

### DIFF
--- a/include/uri_templates.iol
+++ b/include/uri_templates.iol
@@ -1,4 +1,4 @@
-type MatchRequest:void {
+type UriMatchRequest:void {
 	.uri:string
 	.template:string
 }
@@ -15,7 +15,7 @@ WARNING: the API of this service is experimental. Use it at your own risk.
 */
 interface UriTemplatesIface {
 RequestResponse:
-	match(MatchRequest)(MatchResponse),
+	match(UriMatchRequest)(MatchResponse),
 	expand(ExpandRequest)(string)
 }
 


### PR DESCRIPTION
As mentioned in #84, uri_templates.iol and string_utils.iol both define different types named MatchRequest, causing problems if both are included. In the small test I was working on, simply renaming the type in uri_templates.iol seems to work.