### PR TITLE
Updated JsonRpcProtocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ build/
 /extensions/soaps/nbproject/private/
 /extensions/auto/nbproject/private/
 /libjolie/build
+/support/jolie-gwt/build

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ build/
 /jolie/.idea/tasks.xml
 /extensions/soaps/nbproject/private/
 /extensions/auto/nbproject/private/
+/libjolie/build

--- a/extensions/jsonrpc/src/jolie/net/JsonRpcProtocol.java
+++ b/extensions/jsonrpc/src/jolie/net/JsonRpcProtocol.java
@@ -145,9 +145,9 @@ public class JsonRpcProtocol extends SequentialCommProtocol implements HttpUtils
                                     // some implementations need an array here
                                     value.getFirstChild( "params" ).getChildren( JsUtils.JSONARRAY_KEY ).set( 0, message.value() );
                                 }
-                                if ( !message.hasGenericId() ) {
+                                if ( !message.hasGenericId() && !isLsp ) {
                                     value.getFirstChild( "id" ).setValue( message.id() );
-                                }
+                                } 
                         }
 		}
 

--- a/extensions/jsonrpc/src/jolie/net/JsonRpcProtocol.java
+++ b/extensions/jsonrpc/src/jolie/net/JsonRpcProtocol.java
@@ -131,39 +131,24 @@ public class JsonRpcProtocol extends SequentialCommProtocol implements HttpUtils
 			boolean isRR =
 				channel().parentPort().getOperationTypeDescription( message.operationName(), message.resourcePath() )
                                 instanceof RequestResponseTypeDescription;
-                        if ( isLsp ) {
-                            if ( inInputPort && isRR ) {
-                                    value.getChildren( "result" ).set( 0, message.value() );
-                                    String jsonRpcId = jsonRpcIdMap.get( message.id() );
-                                    value.getFirstChild( "id" ).setValue( jsonRpcId != null ? jsonRpcId : Long.toString( message.id() ) );
-                            } else {
-                                    jsonRpcOpMap.put( message.id() + "", message.operationName() );
-                                    value.getFirstChild( "method" ).setValue( message.operationName() );
-                                    if ( message.value().isDefined() || message.value().hasChildren() ) {
-                                        // some implementations need an array here
-                                        value.getFirstChild( "params" ).getChildren( JsUtils.JSONARRAY_KEY ).set( 0, message.value() );
-                                    }
-                                    if ( !message.hasGenericId() ) {
-                                        value.getFirstChild( "id" ).setValue( message.id() );
-                                    }
-                            }
-			} else {
-				if ( inInputPort ) {
-                                        value.getChildren( "result" ).set( 0, message.value() );
-                                        String jsonRpcId = jsonRpcIdMap.get( message.id() );
-                                        value.getFirstChild( "id" ).setValue( jsonRpcId != null ? jsonRpcId : Long.toString( message.id() ) );
-                                } else {
-                                        jsonRpcOpMap.put( message.id() + "", message.operationName() );
-                                        value.getFirstChild( "method" ).setValue( message.operationName() );
-                                        if ( message.value().isDefined() || message.value().hasChildren() ) {
-                                            // some implementations need an array here
-                                            value.getFirstChild( "params" ).getChildren( JsUtils.JSONARRAY_KEY ).set( 0, message.value() );
-                                        }
-                                        if ( !message.hasGenericId() ) {
-                                            value.getFirstChild( "id" ).setValue( message.id() );
-                                        }
+                        //if we are in LSP, we want to be sure the message to be an RR
+                        //in order to send it with the field "result"
+                        boolean check = isLsp ? isRR : true;
+                        if ( inInputPort && check ) {
+                                value.getChildren( "result" ).set( 0, message.value() );
+                                String jsonRpcId = jsonRpcIdMap.get( message.id() );
+                                value.getFirstChild( "id" ).setValue( jsonRpcId != null ? jsonRpcId : Long.toString( message.id() ) );
+                        } else {
+                                jsonRpcOpMap.put( message.id() + "", message.operationName() );
+                                value.getFirstChild( "method" ).setValue( message.operationName() );
+                                if ( message.value().isDefined() || message.value().hasChildren() ) {
+                                    // some implementations need an array here
+                                    value.getFirstChild( "params" ).getChildren( JsUtils.JSONARRAY_KEY ).set( 0, message.value() );
                                 }
-			}
+                                if ( !message.hasGenericId() ) {
+                                    value.getFirstChild( "id" ).setValue( message.id() );
+                                }
+                        }
 		}
 
 		StringBuilder json = new StringBuilder();

--- a/extensions/jsonrpc/src/jolie/net/JsonRpcProtocol.java
+++ b/extensions/jsonrpc/src/jolie/net/JsonRpcProtocol.java
@@ -132,7 +132,7 @@ public class JsonRpcProtocol extends SequentialCommProtocol implements HttpUtils
 				channel().parentPort().getOperationTypeDescription( message.operationName(), message.resourcePath() )
                                 instanceof RequestResponseTypeDescription;
                         //if we are in LSP, we want to be sure the message to be an RR
-                        //in order to send it with the field "result"
+                        //in order to send it with the field "results" and "id"
                         boolean check = isLsp ? isRR : true;
                         if ( inInputPort && check ) {
                                 value.getChildren( "result" ).set( 0, message.value() );


### PR DESCRIPTION
- all test passed
- fixed the problem in which the notifications sent by the server in Lsp mode were with the id field.
- resolving aliases also in send_internal when sending notifications (for instance if the op. name is publishDiagnostics after aliasing it will be textDocument/publishDiagnostics, therefore the client will recognize the message)

PS: in LSP mode now notifications from the server to the client work, but RR not yet.