### PR TITLE
Proposal for RuntimeFaultExceptions

### DIFF
--- a/jolie/src/jolie/process/InitDefinitionProcess.java
+++ b/jolie/src/jolie/process/InitDefinitionProcess.java
@@ -46,7 +46,7 @@ public class InitDefinitionProcess extends DefinitionProcess
 			for( OutputPort outputPort : interpreter.outputPorts() ) {
 				try {
 					outputPort.configurationProcess().run();
-				} catch( FaultException fe ) {
+				} catch( FaultException | FaultException.RuntimeFaultException fe ) {
 					// If this happens, it's been caused by a bug in the SemanticVerifier
 					assert( false );
 				} catch( ExitingException e ) {

--- a/jolie/src/jolie/process/MakePointerProcess.java
+++ b/jolie/src/jolie/process/MakePointerProcess.java
@@ -37,8 +37,8 @@ public class MakePointerProcess implements Process
 	public Process copy( TransformationReason reason )
 	{
 		return new MakePointerProcess(
-				(VariablePath)leftPath.cloneExpression( reason ),
-				(VariablePath)rightPath.cloneExpression( reason )
+				( VariablePath ) leftPath.cloneExpression( reason ),
+				( VariablePath ) rightPath.cloneExpression( reason )
 				);
 	}
 	

--- a/jolie/src/jolie/process/OneWayProcess.java
+++ b/jolie/src/jolie/process/OneWayProcess.java
@@ -91,9 +91,13 @@ public class OneWayProcess implements InputOperationProcess
 
 		Future< SessionMessage > f = ethread.requestMessage( operation, ethread );
 		try {
-			SessionMessage m = f.get();
-			if ( m != null ) { // If it is null, we got killed by a fault
-				receiveMessage( m, ethread.state() ).run();
+			try {
+				SessionMessage m = f.get();
+				if ( m != null ) { // If it is null, we got killed by a fault
+					receiveMessage( m, ethread.state() ).run();
+				}
+			} catch ( FaultException.RuntimeFaultException rf ){
+				throw rf.faultException();
 			}
 		} catch( FaultException e ) {
 			// Should never happen since receiveMessage always
@@ -106,6 +110,7 @@ public class OneWayProcess implements InputOperationProcess
 		} catch( Exception e ) {
 			Interpreter.getInstance().logSevere( e );
 		}
+		
 	}
 
 	private void log( String log, CommMessage message )

--- a/jolie/src/jolie/process/ScopeProcess.java
+++ b/jolie/src/jolie/process/ScopeProcess.java
@@ -60,16 +60,20 @@ public class ScopeProcess implements Process
 			throws ExitingException
 		{
 			try {
-				p.run();
-				if ( ethread.isKilled() ) {
-					shouldMerge = false;
-					p = ethread.getCompensation( id );
-					if ( p != null ) { // Termination handling
-						FaultException f = ethread.killerFault();
-						ethread.clearKill();
-						this.runScope( p );
-						ethread.kill( f );
+				try {
+					p.run();
+					if ( ethread.isKilled() ) {
+						shouldMerge = false;
+						p = ethread.getCompensation( id );
+						if ( p != null ) { // Termination handling
+							FaultException f = ethread.killerFault();
+							ethread.clearKill();
+							this.runScope( p );
+							ethread.kill( f );
+						}
 					}
+				} catch( FaultException.RuntimeFaultException rf ){
+					throw rf.faultException();
 				}
 			} catch( FaultException f ) {
 				p = ethread.getFaultHandler( f.faultName(), true );

--- a/jolie/src/jolie/runtime/FaultException.java
+++ b/jolie/src/jolie/runtime/FaultException.java
@@ -22,7 +22,6 @@
 package jolie.runtime;
 
 import java.io.ByteArrayOutputStream;
-
 import java.io.PrintStream;
 
 /**
@@ -122,4 +121,29 @@ public class FaultException extends Exception
 	{
 		return faultName;
 	}
+
+	public RuntimeFaultException toRuntimeFaultException()
+	{
+		return new RuntimeFaultException( this );
+	}
+	
+	// A RuntimeFaultException is used for runtime errors from which it is 
+	// impossible to recover from and continued execution.
+	// A RuntimeFaultException wraps a FaultException. 
+	// A thrown RuntimeFaultException is caught by the enclosing execution
+	// instance and used to report to the user the enclosed FaultException
+	public class RuntimeFaultException extends RuntimeException {
+		private final FaultException faultException;
+
+		private RuntimeFaultException( FaultException faultException )
+		{
+			this.faultException = faultException;
+		}
+		
+		public FaultException faultException(){
+			return this.faultException;
+		}
+		
+	}
+	
 }

--- a/jolie/src/jolie/runtime/FaultException.java
+++ b/jolie/src/jolie/runtime/FaultException.java
@@ -128,7 +128,7 @@ public class FaultException extends Exception
 	}
 	
 	// A RuntimeFaultException is used for runtime errors from which it is 
-	// impossible to recover from and continued execution.
+	// impossible to recover from and continue the execution.
 	// A RuntimeFaultException wraps a FaultException. 
 	// A thrown RuntimeFaultException is caught by the enclosing execution
 	// instance and used to report to the user the enclosed FaultException

--- a/jolie/src/jolie/runtime/ParallelExecution.java
+++ b/jolie/src/jolie/runtime/ParallelExecution.java
@@ -41,8 +41,12 @@ public class ParallelExecution
 		public void runProcess()
 		{
 			try {
-				process().run();
-				terminationNotify( this );
+				try {
+					process().run();
+					terminationNotify( this );
+				} catch ( FaultException.RuntimeFaultException rf ){
+					throw rf.faultException();
+				}
 			} catch( FaultException f ) {
 				signalFault( this, f );
 			} catch( ExitingException f ) {

--- a/jolie/src/jolie/runtime/SpawnExecution.java
+++ b/jolie/src/jolie/runtime/SpawnExecution.java
@@ -56,8 +56,7 @@ public class SpawnExecution
 			parentSpawnProcess.indexPath().getValue().setValue( index );
 			try {
 				process().run();
-			} catch( FaultException f ) {}
-			catch( ExitingException e ) {}
+			} catch( FaultException | ExitingException | FaultException.RuntimeFaultException f ) {}
 			
 			terminationNotify( this );
 		}

--- a/jolie/src/jolie/runtime/Value.java
+++ b/jolie/src/jolie/runtime/Value.java
@@ -43,7 +43,7 @@ class ValueLink extends Value implements Cloneable
 	private final VariablePath linkPath;
 	private Value getLinkedValue()
 	{
-		return linkPath.getValue();
+		return linkPath.getValue( this );
 	}
 
 	@Override

--- a/jolie/src/jolie/runtime/ValueVector.java
+++ b/jolie/src/jolie/runtime/ValueVector.java
@@ -63,7 +63,7 @@ class ValueVectorLink extends ValueVector implements Cloneable
 	
 	private ValueVector getLinkedValueVector()
 	{
-		return linkPath.getValueVector();
+		return linkPath.getValueVector( this );
 	}
 	
 	@Override

--- a/jolie/src/jolie/runtime/expression/ProductExpression.java
+++ b/jolie/src/jolie/runtime/expression/ProductExpression.java
@@ -22,6 +22,7 @@
 package jolie.runtime.expression;
 
 import jolie.process.TransformationReason;
+import jolie.runtime.FaultException;
 import jolie.runtime.Value;
 
 public class ProductExpression implements Expression
@@ -54,7 +55,11 @@ public class ProductExpression implements Expression
 				val.multiply( children[i].expression().evaluate() );
 				break;
 			case DIVIDE:
-				val.divide( children[i].expression().evaluate() );
+				try {
+						val.divide( children[i].expression().evaluate() );
+				} catch ( ArithmeticException ae ){
+					throw new FaultException( "ArithmeticException", ae.getLocalizedMessage() ).toRuntimeFaultException();
+				}
 				break;
 			case MODULUS:
 				val.modulo( children[i].expression().evaluate() );

--- a/test/primitives/faultHandling.ol
+++ b/test/primitives/faultHandling.ol
@@ -23,22 +23,22 @@ include "../AbstractTestUnit.iol"
 
 define terminationTest
 {
-	i = y = 0;
+	i = y = 0
 	while( i++ < 5 ) {
 		scope( m ) {
-			install( MyFault => comp( s2 ) );
+			install( MyFault => comp( s2 ) )
 			{
 				scope( s1 ) {
 					throw( MyFault )
 				}
 				|
 				scope( s2 ) {
-					install( this => y++ );
+					install( this => y++ )
 					nullProcess
 				}
 			}
 		}
-	};
+	}
 	if ( y != i - 1 ) {
 		throw( TestFailed, "termination/compensation handling in parallel scopes did not work" )
 	}
@@ -49,18 +49,46 @@ define simpleFaultTest
 	scope( s ) {
 		install(
 			MyFault => x = 1
-		);
-		throw( MyFault );
+		)
+		throw( MyFault )
 		x = 5
-	};
+	}
 	if ( x != 1 ) {
 		throw( TestFailed, "an installed fault handler was not executed" )
 	}
 }
 
+define runtimeExceptionTest {
+	scope( ae ) {
+		install( ArithmeticException => z = 1 )
+		z = 1 / 0
+	}
+	if ( z != 1 ){
+		throw( TestFailed, "ArithmeticException not caught correctly" )
+	}
+	scope( aae1 ){
+		install( AliasAccessException => z = 2 )
+		t -> a
+		t -> a.b[ 0 ]
+		c = t
+	}
+	if ( z != 2 ){
+		throw( TestFailed, "AliasAccessException not caught correctly" )
+	}
+	scope( aae2 ){
+		install( AliasAccessException => z = 3 )
+		t -> t
+		d = t
+	}
+	if ( z != 3 ){
+		throw( TestFailed, "AliasAccessException not caught correctly" )
+	}
+}
+
 define doTest
 {
-	simpleFaultTest;
+	simpleFaultTest
 	terminationTest
+	runtimeExceptionTest
 }
 


### PR DESCRIPTION
RuntimeExceptions are useful to handle java RuntimeExceptions (e.g., ArithmeticExceptions).
Currently used to propagate
- ArithmeticExceptions: division by zero
- AliasLoopException: when accessing an alias forms an infinite loop
Added relative tests under the test suite