### PR TITLE
raise a warning when using a variable named as a scope

### DIFF
--- a/jolie/src/main/java/jolie/OOITBuilder.java
+++ b/jolie/src/main/java/jolie/OOITBuilder.java
@@ -1119,6 +1119,9 @@ public class OOITBuilder implements OLVisitor
 	{
 		if (!isLHS) return buildVariablePath(path);
 
+		if ( path == null )
+			return null;
+			
 		final Expression backupExpr = currExpression;
 
 		@SuppressWarnings("unchecked")

--- a/jolie/src/main/java/jolie/OOITBuilder.java
+++ b/jolie/src/main/java/jolie/OOITBuilder.java
@@ -248,7 +248,6 @@ public class OOITBuilder implements OLVisitor
 		new HashMap<>();
 	private final Deque< OLSyntaxNode > lazyVisits = new LinkedList<>();	
 	private boolean firstPass = true;
-	private String currentScopeId = null;
 
 	private static class AggregationConfiguration {
 		private final OutputPort defaultOutputPort;
@@ -295,11 +294,6 @@ public class OOITBuilder implements OLVisitor
 		return context.sourceName() + ":" + context.line() + ": " + message;
 	}
 	
-	private void warning( ParsingContext context, String message )
-	{
-		interpreter.logWarning( buildErrorMessage( context, message ) );
-	}
-
 	private void error( ParsingContext context, String message )
 	{
 		valid = false;
@@ -1022,9 +1016,7 @@ public class OOITBuilder implements OLVisitor
 		
 	public void visit( Scope n )
 	{
-		currentScopeId = n.id();
 		n.body().accept( this );
-		currentScopeId = null;
 		currProcess = new ScopeProcess( n.id(), currProcess );
 	}
 		
@@ -1049,7 +1041,7 @@ public class OOITBuilder implements OLVisitor
 			
 		AssignmentProcess p = 
 			new AssignmentProcess(
-				buildVariablePath( n.variablePath(), true ),
+				buildVariablePath( n.variablePath() ),
 				currExpression, n.context()
 				);
 		currProcess = p;
@@ -1062,7 +1054,7 @@ public class OOITBuilder implements OLVisitor
 
 		AddAssignmentProcess p =
 			new AddAssignmentProcess(
-			buildVariablePath( n.variablePath(), true ),
+			buildVariablePath( n.variablePath() ),
 			currExpression );
 		currProcess = p;
 		currExpression = p;
@@ -1074,7 +1066,7 @@ public class OOITBuilder implements OLVisitor
 
 		SubtractAssignmentProcess p =
 			new SubtractAssignmentProcess(
-			buildVariablePath( n.variablePath(), true ),
+			buildVariablePath( n.variablePath() ),
 			currExpression, n.context() );
 		currProcess = p;
 		currExpression = p;
@@ -1086,7 +1078,7 @@ public class OOITBuilder implements OLVisitor
 
 		MultiplyAssignmentProcess p =
 			new MultiplyAssignmentProcess(
-			buildVariablePath( n.variablePath(), true ),
+			buildVariablePath( n.variablePath() ),
 			currExpression );
 		currProcess = p;
 		currExpression = p;
@@ -1098,7 +1090,7 @@ public class OOITBuilder implements OLVisitor
 
 		DivideAssignmentProcess p =
 			new DivideAssignmentProcess(
-			buildVariablePath( n.variablePath(), true ),
+			buildVariablePath( n.variablePath() ),
 			currExpression );
 		currProcess = p;
 		currExpression = p;
@@ -1113,53 +1105,6 @@ public class OOITBuilder implements OLVisitor
 		));
 		csetVarPathNode.path().addAll( path.path() );
 		return buildVariablePath( csetVarPathNode );
-	}
-
-	private VariablePath buildVariablePath( VariablePathNode path, boolean isLHS )
-	{
-		if (!isLHS) return buildVariablePath(path);
-
-		if ( path == null )
-			return null;
-			
-		final Expression backupExpr = currExpression;
-
-		@SuppressWarnings("unchecked")
-		int pathSize = path.path().size();
-		Pair< Expression, Expression >[] internalPath = new Pair[ pathSize ];
-		
-		// perform check if variable root path is conflicted with scope name
-		Pair< OLSyntaxNode, OLSyntaxNode > currPathPair = path.path().get( 0 );
-		currPathPair.key().accept( this );
-		Expression keyExpr = currExpression;
-		if ( currentScopeId != null && keyExpr.evaluate().strValue().equals( currentScopeId ) ) {
-			warning( path.context(),
-					"DEPRECATION: usage of same variable name as scope name " + currentScopeId );
-		}
-		if ( currPathPair.value() != null ) {
-			currPathPair.value().accept( this );
-		} else {
-			currExpression = null;
-		}
-		internalPath[0] = new Pair<>( keyExpr, currExpression );
-
-		for (int i = 1; i < pathSize; i++) {
-			currPathPair = path.path().get( i );
-			currPathPair.key().accept( this );
-			keyExpr = currExpression;
-			if ( currPathPair.value() != null ) {
-				currPathPair.value().accept( this );
-			} else {
-				currExpression = null;
-			}
-			internalPath[i] = new Pair<>( keyExpr, currExpression );
-		}
-
-		currExpression = backupExpr;
-
-		return path.isGlobal() ? new GlobalVariablePath( internalPath )
-				: new VariablePath( internalPath );
-
 	}
 	
 	private VariablePath buildVariablePath( VariablePathNode path )
@@ -1196,7 +1141,7 @@ public class OOITBuilder implements OLVisitor
 	{
 		currProcess =
 			new MakePointerProcess(
-				buildVariablePath( n.leftPath(), true ),
+				buildVariablePath( n.leftPath() ),
 				buildVariablePath( n.rightPath() ), n.context()
 			);
 	}
@@ -1205,7 +1150,7 @@ public class OOITBuilder implements OLVisitor
 	{
 		currProcess =
 			new DeepCopyProcess(
-				buildVariablePath( n.leftPath(), true ),
+				buildVariablePath( n.leftPath() ),
 				buildExpression( n.rightExpression() ),
 				n.copyLinks(), n.context()
 			);

--- a/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
+++ b/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
@@ -182,6 +182,8 @@ public class SemanticVerifier implements OLVisitor
 	private OperationType insideCourierOperationType = null;
 	private InputPortInfo courierInputPort = null;
 
+	private Scope currentScope = null;
+
 	public SemanticVerifier( Program program, Configuration configuration )
 	{
 		this.program = program;
@@ -212,6 +214,10 @@ public class SemanticVerifier implements OLVisitor
 
 	private void encounteredAssignment( String varName )
 	{
+		if ( this.currentScope != null && this.currentScope.id().equals( varName ) ) {
+			warning( currentScope, "DEPRECATION: usage of same variable name \""+ varName + "\" inside scope \""+ varName + "\"" );
+		}
+
 		if ( isConstantMap.containsKey( varName ) ) {
 			isConstantMap.put( varName, false );
 		} else {
@@ -806,7 +812,9 @@ public class SemanticVerifier implements OLVisitor
 	@Override
 	public void visit( Scope n )
 	{
+		currentScope = n;
 		n.body().accept( this );
+		currentScope = null;
 	}
 	
 	@Override


### PR DESCRIPTION
log deprecate if there is an usage of scope's variable name in LHS of statements.

changes OOITBuilder:
- new overload function buildVariablePath accepts new boolean indicates if building path is LHS expression and perform checks of root varpath name to scope id
- all visit methods for assignment related node uses methods created above
- new class scope field currScopeId to store scopeId context
- warning method in OOITBuilder