### PR TITLE
CorrelationSet guardName as a type

### DIFF
--- a/libjolie/src/main/java/jolie/lang/parse/OLParser.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParser.java
@@ -606,7 +606,10 @@ public class OLParser extends AbstractParser {
 					typeName = token.content();
 					nextToken();
 					eat( Scanner.TokenType.DOT, "expected . after message type name in correlation alias" );
-					aliases.add( new CorrelationAliasInfo( typeName, parseVariablePath() ) );
+					TypeDefinition aliasType =
+						definedTypes.getOrDefault( typeName, new TypeDefinitionLink( getContext(),
+							typeName, Constants.RANGE_ONE_TO_ONE, typeName ) );
+					aliases.add( new CorrelationAliasInfo( aliasType, parseVariablePath() ) );
 				}
 				variables.add( new CorrelationVariableInfo( correlationVariablePath, aliases ) );
 				if( token.is( Scanner.TokenType.COMMA ) ) {

--- a/libjolie/src/main/java/jolie/lang/parse/OLParser.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParser.java
@@ -2933,6 +2933,7 @@ public class OLParser extends AbstractParser {
 	private void parseImport() throws IOException, ParserException {
 
 		if( token.is( Scanner.TokenType.FROM ) ) {
+			ParsingContext context = getContext();
 			boolean isNamespaceImport = false;
 			nextToken();
 			List< String > importTarget = new ArrayList<>();
@@ -2984,9 +2985,9 @@ public class OLParser extends AbstractParser {
 			}
 			ImportStatement stmt = null;
 			if( isNamespaceImport ) {
-				stmt = new ImportStatement( getContext(), Collections.unmodifiableList( importTarget ) );
+				stmt = new ImportStatement( context, Collections.unmodifiableList( importTarget ) );
 			} else {
-				stmt = new ImportStatement( getContext(), Collections.unmodifiableList( importTarget ),
+				stmt = new ImportStatement( context, Collections.unmodifiableList( importTarget ),
 					Collections.unmodifiableList( pathNodes ) );
 			}
 			programBuilder.addChild( stmt );

--- a/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
+++ b/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
@@ -294,7 +294,7 @@ public class SemanticVerifier implements OLVisitor {
 				for( CorrelationAliasInfo alias : csetVar.aliases() ) {
 					checkCorrelationAlias( alias );
 
-					operations = inputTypeNameMap.get( alias.guardName() );
+					operations = inputTypeNameMap.get( alias.guardName().id() );
 					for( String operationName : operations ) {
 						currCorrelatingOperations.add( operationName );
 						correlationFunctionInfo.putCorrelationPair(
@@ -329,7 +329,7 @@ public class SemanticVerifier implements OLVisitor {
 	}
 
 	private void checkCorrelationAlias( CorrelationAliasInfo alias ) {
-		TypeDefinition type = definedTypes.get( alias.guardName() );
+		TypeDefinition type = alias.guardName();
 		if( type == null ) {
 			error( alias.variablePath(), "type " + alias.guardName() + " is undefined" );
 		} else if( type.containsPath( alias.variablePath() ) == false ) {

--- a/libjolie/src/main/java/jolie/lang/parse/ast/CorrelationSetInfo.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/CorrelationSetInfo.java
@@ -26,21 +26,22 @@ import java.util.List;
 
 import jolie.lang.Constants;
 import jolie.lang.parse.OLVisitor;
+import jolie.lang.parse.ast.types.TypeDefinition;
 import jolie.lang.parse.context.ParsingContext;
 
 public class CorrelationSetInfo extends OLSyntaxNode {
 	public static class CorrelationAliasInfo implements Serializable {
 		private static final long serialVersionUID = Constants.serialVersionUID();
 
-		private final String guardName;
+		private final TypeDefinition guardName;
 		private final VariablePathNode variablePath;
 
-		public CorrelationAliasInfo( String guardName, VariablePathNode variablePath ) {
+		public CorrelationAliasInfo( TypeDefinition guardName, VariablePathNode variablePath ) {
 			this.guardName = guardName;
 			this.variablePath = variablePath;
 		}
 
-		public String guardName() {
+		public TypeDefinition guardName() {
 			return guardName;
 		}
 

--- a/libjolie/src/main/java/jolie/lang/parse/module/ModuleCrawler.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/ModuleCrawler.java
@@ -41,7 +41,7 @@ class ModuleCrawler {
 		}
 
 		private void addModuleRecord( ModuleRecord mr ) {
-			this.moduleCrawled.put( mr.source(), mr );
+			this.moduleCrawled.put( mr.uri(), mr );
 		}
 
 		private boolean isRecordInResult( URI source ) {
@@ -54,7 +54,7 @@ class ModuleCrawler {
 
 		public Map< URI, SymbolTable > symbolTables() {
 			Map< URI, SymbolTable > result = new HashMap<>();
-			this.moduleCrawled.values().stream().forEach( mr -> result.put( mr.source(), mr.symbolTable() ) );
+			this.moduleCrawled.values().stream().forEach( mr -> result.put( mr.uri(), mr.symbolTable() ) );
 			return result;
 		}
 	}
@@ -62,7 +62,7 @@ class ModuleCrawler {
 	private static final Map< URI, ModuleRecord > CACHE = new ConcurrentHashMap<>();
 
 	private static void putToCache( ModuleRecord mc ) {
-		ModuleCrawler.CACHE.put( mc.source(), mc );
+		ModuleCrawler.CACHE.put( mc.uri(), mc );
 	}
 
 	private static boolean inCache( URI source ) {
@@ -91,7 +91,7 @@ class ModuleCrawler {
 		for( ImportedSymbolInfo importedSymbol : record.symbolTable().importedSymbolInfos() ) {
 			try {
 				ModuleSource moduleSource =
-					this.findModule( importedSymbol.importPath(), record.source() );
+					this.findModule( importedSymbol.importPath(), record.uri() );
 				importedSymbol.setModuleSource( moduleSource );
 				modulesToCrawl.add( moduleSource );
 			} catch( ModuleNotFoundException e ) {

--- a/libjolie/src/main/java/jolie/lang/parse/module/ModuleFinderImpl.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/ModuleFinderImpl.java
@@ -102,20 +102,15 @@ public class ModuleFinderImpl implements ModuleFinder {
 			errMessageList.add( e.getMessage() );
 		}
 
-		try {
-			// 3. Try to resolve P from the list of packages directories.
-			ModuleSource moduleFile = null;
-			for( Path packagePath : this.packagePaths ) {
-				moduleFile = moduleLookup( packagePath, importPath );
-				if( moduleFile != null ) {
-					break;
-				}
+		// 3. Try to resolve P from the list of packages directories.
+		for( Path packagePath : this.packagePaths ) {
+			try {
+				ModuleSource moduleFile = moduleLookup( packagePath, importPath );
+				return moduleFile;
+			} catch( FileNotFoundException e ) {
+				errMessageList.add( e.getMessage() );
 			}
-			return moduleFile;
-		} catch( FileNotFoundException e ) {
-			errMessageList.add( e.getMessage() );
 		}
-
 		throw new ModuleNotFoundException( importPath.pathParts().toString(), errMessageList );
 	}
 

--- a/libjolie/src/main/java/jolie/lang/parse/module/ModuleRecord.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/ModuleRecord.java
@@ -23,16 +23,15 @@ import java.net.URI;
 import jolie.lang.parse.ast.Program;
 
 /**
- * A class represent a Jolie module record, which contain an URI of source, a AST tree and
- * Symboltable
+ * A class represent a Jolie module record, which contain an uri, a AST tree and Symboltable
  */
 public class ModuleRecord {
-	private final URI source;
+	private final URI uri;
 	private final Program program;
 	private final SymbolTable symbolTable;
 
-	public ModuleRecord( URI source, Program program, SymbolTable symbolTable ) {
-		this.source = source;
+	public ModuleRecord( URI uri, Program program, SymbolTable symbolTable ) {
+		this.uri = uri;
 		this.program = program;
 		this.symbolTable = symbolTable;
 	}
@@ -40,19 +39,19 @@ public class ModuleRecord {
 	/**
 	 * @return the absolute URI to the Module
 	 */
-	public URI source() {
-		return source;
+	public URI uri() {
+		return uri;
 	}
 
 	/**
-	 * @return a parsed AST respected to source URI
+	 * @return a parsed AST respected to uri URI
 	 */
 	public Program program() {
 		return program;
 	}
 
 	/**
-	 * @return the symbolTable respected to source URI
+	 * @return the symbolTable respected to uri URI
 	 */
 	public SymbolTable symbolTable() {
 		return symbolTable;
@@ -60,7 +59,7 @@ public class ModuleRecord {
 
 	@Override
 	public String toString() {
-		return "ModuleRecord [source=" + source + ", symbolTable=" + symbolTable + "]";
+		return "ModuleRecord [uri=" + uri + ", symbolTable=" + symbolTable + "]";
 	}
 
 

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
@@ -32,6 +32,8 @@ import jolie.lang.parse.ast.AssignStatement;
 import jolie.lang.parse.ast.CompareConditionNode;
 import jolie.lang.parse.ast.CompensateStatement;
 import jolie.lang.parse.ast.CorrelationSetInfo;
+import jolie.lang.parse.ast.CorrelationSetInfo.CorrelationAliasInfo;
+import jolie.lang.parse.ast.CorrelationSetInfo.CorrelationVariableInfo;
 import jolie.lang.parse.ast.CurrentHandlerStatement;
 import jolie.lang.parse.ast.DeepCopyStatement;
 import jolie.lang.parse.ast.DefinitionCallStatement;
@@ -357,7 +359,13 @@ class SymbolReferenceResolver {
 		public void visit( ExecutionInfo n ) {}
 
 		@Override
-		public void visit( CorrelationSetInfo n ) {}
+		public void visit( CorrelationSetInfo n ) {
+			for( CorrelationVariableInfo cSetVar : n.variables() ) {
+				for( CorrelationAliasInfo aliases : cSetVar.aliases() ) {
+					aliases.guardName().accept( this );
+				}
+			}
+		}
 
 		@Override
 		public void visit( InputPortInfo n ) {

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
@@ -691,7 +691,7 @@ class SymbolReferenceResolver {
 		this.moduleMap = moduleMap.toMap();
 		this.symbolTables = new HashMap<>();
 		for( ModuleRecord mr : this.moduleMap.values() ) {
-			this.symbolTables.put( mr.source(), mr.symbolTable() );
+			this.symbolTables.put( mr.uri(), mr.symbolTable() );
 		}
 	}
 
@@ -709,10 +709,10 @@ class SymbolReferenceResolver {
 			this.moduleMap.get( symbolInfo.moduleSource().get().uri() );
 		Optional< SymbolInfo > externalSourceSymbol =
 			externalSourceRecord.symbolTable().getSymbol( symbolInfo.originalSymbolName() );
-		if( !externalSourceSymbol.isPresent() || lookedSources.contains( externalSourceRecord.source() ) ) {
+		if( !externalSourceSymbol.isPresent() || lookedSources.contains( externalSourceRecord.uri() ) ) {
 			throw new SymbolNotFoundException( symbolInfo.name(), symbolInfo.importPath() );
 		}
-		lookedSources.add( externalSourceRecord.source() );
+		lookedSources.add( externalSourceRecord.uri() );
 		if( externalSourceSymbol.get().scope() == Scope.LOCAL ) {
 			return externalSourceSymbol.get();
 		} else {


### PR DESCRIPTION
- Change CorrelationAliasInfo.guardName field type from String to TypeDefinition, which will be visited and resolved to a proper Symbol node in SymbolReferenceResolver.resolve. 

- SematicVerifier.checkCorrelationSets directly uses the pointer to build a CorrelationFuncitonInfo.

This change allows usage of imported symbols in cset eg.

```
from .point import pointType

cset{
  pointX : pointType.x
}
...
```