### PR TITLE
Fix missing type during initializing an internal service node.

### DIFF
--- a/libjolie/src/main/java/jolie/lang/parse/OLParser.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParser.java
@@ -1304,7 +1304,8 @@ public class OLParser extends AbstractParser {
 
 		// copy children of parent to embedded service
 		for( OLSyntaxNode child : parentProgramBuilder.children() ) {
-			if( child instanceof OutputPortInfo ) {
+			if( child instanceof OutputPortInfo
+				|| child instanceof TypeDefinition ) {
 				internalServiceProgramBuilder.addChild( child );
 			}
 		}


### PR DESCRIPTION
By add type definition from parent program to the internal service node.