### PR TITLE
Commandline argument for specify an execution service and logic for service target selection

### DIFF
--- a/javaServices/coreJavaServices/src/main/java/joliex/lang/inspector/Inspector.java
+++ b/javaServices/coreJavaServices/src/main/java/joliex/lang/inspector/Inspector.java
@@ -145,11 +145,12 @@ public class Inspector extends JavaService {
 
 	private static ProgramInspector getInspector( String filename, Optional< String > source, String[] includePaths )
 		throws CommandLineException, IOException, ParserException, CodeCheckingException, ModuleException {
-		SemanticVerifier.Configuration configuration = new SemanticVerifier.Configuration();
-		configuration.setCheckForMain( false );
 		String[] args = { filename };
 		Interpreter.Configuration interpreterConfiguration =
 			new CommandLineParser( args, Inspector.class.getClassLoader() ).getInterpreterConfiguration();
+		SemanticVerifier.Configuration configuration =
+			new SemanticVerifier.Configuration( interpreterConfiguration.executionTarget() );
+		configuration.setCheckForMain( false );
 		final InputStream sourceIs;
 		if( source.isPresent() ) {
 			sourceIs = new ByteArrayInputStream( source.get().getBytes() );

--- a/javaServices/coreJavaServices/src/main/java/joliex/meta/MetaJolie.java
+++ b/javaServices/coreJavaServices/src/main/java/joliex/meta/MetaJolie.java
@@ -835,7 +835,9 @@ public class MetaJolie extends JavaService {
 				cmdParser.getInterpreterConfiguration().includePaths(),
 				cmdParser.getInterpreterConfiguration().packagePaths(),
 				cmdParser.getInterpreterConfiguration().jolieClassLoader(),
-				cmdParser.getInterpreterConfiguration().constants(), true );
+				cmdParser.getInterpreterConfiguration().constants(),
+				cmdParser.getInterpreterConfiguration().executionTarget(),
+				true );
 			ProgramInspector inspector = ParsingUtils.createInspector( program );
 
 			URI originalFile = program.context().source();
@@ -895,7 +897,9 @@ public class MetaJolie extends JavaService {
 				cmdParser.getInterpreterConfiguration().includePaths(),
 				cmdParser.getInterpreterConfiguration().packagePaths(),
 				cmdParser.getInterpreterConfiguration().jolieClassLoader(),
-				cmdParser.getInterpreterConfiguration().constants(), true );
+				cmdParser.getInterpreterConfiguration().constants(),
+				cmdParser.getInterpreterConfiguration().executionTarget(),
+				true );
 			ProgramInspector inspector = ParsingUtils.createInspector( program );
 
 			OutputPortInfo[] outputPortList = inspector.getOutputPorts();
@@ -981,7 +985,9 @@ public class MetaJolie extends JavaService {
 				cmdParser.getInterpreterConfiguration().includePaths(),
 				cmdParser.getInterpreterConfiguration().packagePaths(),
 				cmdParser.getInterpreterConfiguration().jolieClassLoader(),
-				cmdParser.getInterpreterConfiguration().constants(), true );
+				cmdParser.getInterpreterConfiguration().constants(),
+				cmdParser.getInterpreterConfiguration().executionTarget(),
+				true );
 			ProgramInspector inspector = ParsingUtils.createInspector( program );
 
 			URI originalFile = program.context().source();

--- a/jolie/src/main/java/jolie/CommandLineParser.java
+++ b/jolie/src/main/java/jolie/CommandLineParser.java
@@ -158,8 +158,8 @@ public class CommandLineParser implements Closeable {
 				getOptionString( "--charset [character encoding, e.g., UTF-8]",
 					"Character encoding of the source *.ol/*.iol (default: system-dependent, on GNU/Linux UTF-8)" ) )
 			.append(
-				getOptionString( "--main [service name]",
-					"Specify a service in the module to execute (default 'main')" ) )
+				getOptionString( "-s [service name], --service [service name]",
+					"Specify a service in the module to execute (not necessary if the module contains only one service definition)" ) )
 			.append(
 				getOptionString( "--version", "Display this program version information" ) )
 			.append(

--- a/jolie/src/main/java/jolie/CommandLineParser.java
+++ b/jolie/src/main/java/jolie/CommandLineParser.java
@@ -270,7 +270,7 @@ public class CommandLineParser implements Closeable {
 		int cLimit = -1;
 		long rTimeout = 36000 * 1000; // 10 minutes
 		String pwd = UriUtils.normalizeWindowsPath( new File( "" ).getCanonicalPath() );
-		String tMain = "main";
+		String tService = null;
 		includeList.add( pwd );
 		includeList.add( "include" );
 		libList.add( pwd );
@@ -420,10 +420,13 @@ public class CommandLineParser implements Closeable {
 							"The number specified for cellId (" + argsList.get( i ) + ") is not allowed. Set to 0" );
 				}
 				optionsList.add( argsList.get( i ) );
-			} else if( "--main".equals( argsList.get( i ) ) ) {
+			} else if( "--service".equals( argsList.get( i ) ) || "-s".equals( argsList.get( i ) ) ) {
 				optionsList.add( argsList.get( i ) );
 				i++;
-				tMain = argsList.get( i );
+				if( tService != null ) {
+					throw new CommandLineException( "Execution service is already defined" );
+				}
+				tService = argsList.get( i );
 				optionsList.add( argsList.get( i ) );
 			} else if( "--version".equals( argsList.get( i ) ) ) {
 				throw new CommandLineException( getVersionString() );
@@ -479,7 +482,7 @@ public class CommandLineParser implements Closeable {
 		tracerMode = tMode;
 		tracerLevel = tLevel;
 		printStackTraces = bStackTraces;
-		executionTarget = tMain;
+		executionTarget = tService;
 
 		correlationAlgorithmType = CorrelationEngine.Type.fromString( csetAlgorithmName );
 		if( correlationAlgorithmType == null ) {

--- a/jolie/src/main/java/jolie/CommandLineParser.java
+++ b/jolie/src/main/java/jolie/CommandLineParser.java
@@ -86,6 +86,7 @@ public class CommandLineParser implements Closeable {
 	private final long responseTimeout;
 	private final boolean printStackTraces;
 	private final Level logLevel;
+	private final String executionTarget;
 	private File programDirectory = null;
 	private int cellId = 0;
 
@@ -156,6 +157,9 @@ public class CommandLineParser implements Closeable {
 			.append(
 				getOptionString( "--charset [character encoding, e.g., UTF-8]",
 					"Character encoding of the source *.ol/*.iol (default: system-dependent, on GNU/Linux UTF-8)" ) )
+			.append(
+				getOptionString( "--main [service name]",
+					"Specify a service in the module to execute (default 'main')" ) )
 			.append(
 				getOptionString( "--version", "Display this program version information" ) )
 			.append(
@@ -266,6 +270,7 @@ public class CommandLineParser implements Closeable {
 		int cLimit = -1;
 		long rTimeout = 36000 * 1000; // 10 minutes
 		String pwd = UriUtils.normalizeWindowsPath( new File( "" ).getCanonicalPath() );
+		String tMain = "main";
 		includeList.add( pwd );
 		includeList.add( "include" );
 		libList.add( pwd );
@@ -415,6 +420,11 @@ public class CommandLineParser implements Closeable {
 							"The number specified for cellId (" + argsList.get( i ) + ") is not allowed. Set to 0" );
 				}
 				optionsList.add( argsList.get( i ) );
+			} else if( "--main".equals( argsList.get( i ) ) ) {
+				optionsList.add( argsList.get( i ) );
+				i++;
+				tMain = argsList.get( i );
+				optionsList.add( argsList.get( i ) );
 			} else if( "--version".equals( argsList.get( i ) ) ) {
 				throw new CommandLineException( getVersionString() );
 			} else if( (olFilepath == null) && (argsList.get( i ).endsWith( ".jap" )
@@ -469,6 +479,7 @@ public class CommandLineParser implements Closeable {
 		tracerMode = tMode;
 		tracerLevel = tLevel;
 		printStackTraces = bStackTraces;
+		executionTarget = tMain;
 
 		correlationAlgorithmType = CorrelationEngine.Type.fromString( csetAlgorithmName );
 		if( correlationAlgorithmType == null ) {
@@ -767,7 +778,8 @@ public class CommandLineParser implements Closeable {
 			responseTimeout,
 			logLevel,
 			programDirectory,
-			packagePaths );
+			packagePaths,
+			executionTarget );
 
 	}
 

--- a/jolie/src/main/java/jolie/Interpreter.java
+++ b/jolie/src/main/java/jolie/Interpreter.java
@@ -887,7 +887,7 @@ public class Interpreter {
 			tracer = new DummyTracer();
 		}
 
-		LOGGER.setLevel( Level.ALL );
+		LOGGER.setLevel( configuration.logLevel() );
 
 		exitingLock = new ReentrantLock();
 		exitingCondition = exitingLock.newCondition();

--- a/jolie/src/main/java/jolie/Interpreter.java
+++ b/jolie/src/main/java/jolie/Interpreter.java
@@ -887,7 +887,7 @@ public class Interpreter {
 			tracer = new DummyTracer();
 		}
 
-		LOGGER.setLevel( configuration.logLevel() );
+		LOGGER.setLevel( Level.ALL );
 
 		exitingLock = new ReentrantLock();
 		exitingCondition = exitingLock.newCondition();

--- a/jolie/src/main/java/jolie/Interpreter.java
+++ b/jolie/src/main/java/jolie/Interpreter.java
@@ -1255,13 +1255,13 @@ public class Interpreter {
 
 			final SemanticVerifier semanticVerifier;
 
+			SemanticVerifier.Configuration conf =
+				new SemanticVerifier.Configuration( configuration.executionTarget() );
+
 			if( check ) {
-				SemanticVerifier.Configuration conf = new SemanticVerifier.Configuration();
 				conf.setCheckForMain( false );
-				semanticVerifier = new SemanticVerifier( program, symbolTables, conf );
-			} else {
-				semanticVerifier = new SemanticVerifier( program, symbolTables );
 			}
+			semanticVerifier = new SemanticVerifier( program, symbolTables, conf );
 
 			try {
 				semanticVerifier.validate();
@@ -1444,6 +1444,7 @@ public class Interpreter {
 		private final Level logLevel;
 		private final File programDirectory;
 		private final String[] packagePaths;
+		private final String executionTarget;
 
 		private Configuration( int connectionsLimit,
 			CorrelationEngine.Type correlationAlgorithm,
@@ -1466,7 +1467,8 @@ public class Interpreter {
 			long responseTimeout,
 			Level logLevel,
 			File programDirectory,
-			String[] packagePaths ) {
+			String[] packagePaths,
+			String executionTarget ) {
 			this.connectionsLimit = connectionsLimit;
 			this.correlationAlgorithm = correlationAlgorithm;
 			this.includePaths = includeList;
@@ -1489,6 +1491,7 @@ public class Interpreter {
 			this.logLevel = logLevel;
 			this.programDirectory = programDirectory;
 			this.packagePaths = packagePaths;
+			this.executionTarget = executionTarget;
 		}
 
 		public static Configuration create( int connectionsLimit,
@@ -1512,11 +1515,12 @@ public class Interpreter {
 			long responseTimeout,
 			Level logLevel,
 			File programDirectory,
-			String[] packagePaths ) {
+			String[] packagePaths,
+			String executionTarget ) {
 			return new Configuration( connectionsLimit, correlationAlgorithm, includeList, optionArgs, libUrls,
 				inputStream, charset, programFilepath, arguments, constants, jolieClassLoader, programCompiled,
 				typeCheck, tracer, tracerLevel, tracerMode, check, printStackTraces, responseTimeout, logLevel,
-				programDirectory, packagePaths );
+				programDirectory, packagePaths, executionTarget );
 		}
 
 		public static Configuration create( Configuration config,
@@ -1526,7 +1530,7 @@ public class Interpreter {
 				config.libURLs, inputStream, config.charset, programFilepath, config.arguments, config.constants,
 				config.jolieClassLoader, config.isProgramCompiled, config.typeCheck, config.tracer, config.tracerLevel,
 				config.tracerMode, config.check, config.printStackTraces, config.responseTimeout, config.logLevel,
-				config.programDirectory, config.packagePaths );
+				config.programDirectory, config.packagePaths, config.executionTarget );
 		}
 
 		/**
@@ -1696,6 +1700,15 @@ public class Interpreter {
 
 		public boolean printStackTraces() {
 			return printStackTraces;
+		}
+
+		/**
+		 * Returns the execution service target of this interpreter.
+		 *
+		 * @return the execution service target of this interpreter.
+		 */
+		public String executionTarget() {
+			return this.executionTarget;
 		}
 
 		/**

--- a/jolie/src/main/java/jolie/OOITBuilder.java
+++ b/jolie/src/main/java/jolie/OOITBuilder.java
@@ -1692,7 +1692,7 @@ public class OOITBuilder implements OLVisitor {
 
 	@Override
 	public void visit( ServiceNode n ) {
-		if( n.name().equals( "main" ) ) {
+		if( n.name().equals( this.interpreter.configuration().executionTarget() ) ) {
 			n.program().accept( this );
 		}
 	}

--- a/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
+++ b/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
@@ -20,10 +20,18 @@
 package jolie.lang.parse;
 
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.logging.Logger;
-
 import jolie.lang.CodeCheckingError;
 import jolie.lang.CodeCheckingException;
 import jolie.lang.Constants.ExecutionMode;
@@ -193,12 +201,15 @@ public class SemanticVerifier implements OLVisitor {
 
 	private final Deque< String > inScopes = new ArrayDeque<>();
 
+	private final Map< String, ServiceNode > services;
+
 	public SemanticVerifier( Program program, Map< URI, SymbolTable > symbolTables,
 		Configuration configuration ) {
 		this.program = program;
 		this.definedTypes = OLParser.createTypeDeclarationMap( program.context() );
 		this.configuration = configuration;
 		this.symbolTables = symbolTables;
+		this.services = new HashMap<>();
 	}
 
 	public CorrelationFunctionInfo correlationFunctionInfo() {
@@ -355,12 +366,28 @@ public class SemanticVerifier implements OLVisitor {
 	public void validate()
 		throws CodeCheckingException {
 		program.accept( this );
+		if( services.values().size() == 0 ) {
+			// this is an jolie's internal service (service with Interfaces)
+			if( configuration.checkForMain && !mainDefined ) {
+				error( program, "Main procedure is not defined" );
+			}
+		} else {
+			ServiceNode executionService = null;
+			if( services.values().size() == 1 ) {
+				executionService = services.values().iterator().next();
+			} else if( services.values().size() > 1 ) {
+				executionService = services.get( configuration.executionTarget );
+			}
+			if( executionService == null ) {
+				error( program, "Execution service is not defined" );
+			}
+			executionService.program().accept( this );
+			if( configuration.checkForMain && !mainDefined ) {
+				error( program, "Main procedure for service " + configuration.executionTarget + " is not defined" );
+			}
+		}
 		checkToBeEqualTypes();
 		checkCorrelationSets();
-
-		if( configuration.checkForMain && mainDefined == false ) {
-			error( null, "Main service or main procedure not defined" );
-		}
 
 		if( !errors.isEmpty() ) {
 			LOGGER.severe( "Aborting: input file semantically invalid." );
@@ -1320,9 +1347,7 @@ public class SemanticVerifier implements OLVisitor {
 
 	@Override
 	public void visit( ServiceNode n ) {
-		if( n.name().equals( this.configuration.executionTarget() ) ) {
-			n.program().accept( this );
-		}
+		this.services.put( n.name(), n );
 	}
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
+++ b/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
@@ -132,6 +132,11 @@ import jolie.util.Pair;
 public class SemanticVerifier implements OLVisitor {
 	public static class Configuration {
 		private boolean checkForMain = true;
+		private final String executionTarget;
+
+		public Configuration( String executionTarget ) {
+			this.executionTarget = executionTarget;
+		}
 
 		public void setCheckForMain( boolean checkForMain ) {
 			this.checkForMain = checkForMain;
@@ -139,6 +144,10 @@ public class SemanticVerifier implements OLVisitor {
 
 		public boolean checkForMain() {
 			return checkForMain;
+		}
+
+		public String executionTarget() {
+			return executionTarget;
 		}
 	}
 
@@ -190,10 +199,6 @@ public class SemanticVerifier implements OLVisitor {
 		this.definedTypes = OLParser.createTypeDeclarationMap( program.context() );
 		this.configuration = configuration;
 		this.symbolTables = symbolTables;
-	}
-
-	public SemanticVerifier( Program program, Map< URI, SymbolTable > symbolTables ) {
-		this( program, symbolTables, new Configuration() );
 	}
 
 	public CorrelationFunctionInfo correlationFunctionInfo() {
@@ -1315,7 +1320,7 @@ public class SemanticVerifier implements OLVisitor {
 
 	@Override
 	public void visit( ServiceNode n ) {
-		if( n.name().equals( "main" ) ) {
+		if( n.name().equals( this.configuration.executionTarget() ) ) {
 			n.program().accept( this );
 		}
 	}

--- a/libjolie/src/main/java/jolie/lang/parse/util/ParsingUtils.java
+++ b/libjolie/src/main/java/jolie/lang/parse/util/ParsingUtils.java
@@ -81,6 +81,7 @@ public class ParsingUtils {
 		String[] packagePaths,
 		ClassLoader classLoader,
 		Map< String, Scanner.Token > definedConstants,
+		String executionTarget,
 		boolean includeDocumentation )
 		throws IOException, ParserException, CodeCheckingException, ModuleException {
 		return parseProgram(
@@ -91,7 +92,7 @@ public class ParsingUtils {
 			packagePaths,
 			classLoader,
 			definedConstants,
-			new SemanticVerifier.Configuration(),
+			new SemanticVerifier.Configuration( executionTarget ),
 			includeDocumentation );
 	}
 

--- a/test/primitives/private/service_node_multi_services.ol
+++ b/test/primitives/private/service_node_multi_services.ol
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 Narongrit Unwerawattana <narongrit.kie@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+/**
+    Variable path node as an argument
+*/
+
+type parenParam: void{
+    a : string
+    child :childParam 
+}
+
+type childParam : void{
+    a : string
+    b : int
+}
+
+service ParentService(p : parenParam) {
+
+    inputPort ip {
+        location:"local"
+        requestResponse: testParam(void)(void) throws TestFailed(any)
+    }
+
+    embed ChildService(p.child) as Child
+
+    main{
+        testParam()(){
+            if (!(p instanceof parenParam)){
+                throw(TestFailed, "passing argument is invalid type, expected \"parenParam\"")
+            }
+            testParam@Child()()
+        }
+    }
+}
+
+service ChildService(p : childParam) {
+
+    inputPort ip {
+        location:"local"
+        requestResponse: testParam(void)(void) throws TestFailed(any)
+    }
+
+    main{
+        testParam()(){
+            if (!(p instanceof childParam)){
+                throw(TestFailed, "passing argument is invalid type, expected \"childParam\"")
+            }
+        }
+    }
+}

--- a/test/primitives/private/service_node_param_custom.ol
+++ b/test/primitives/private/service_node_param_custom.ol
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Narongrit Unwerawattana <narongrit.kie@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+ 
+type testParam :int {
+    a:string
+    b:void{
+        a:int
+    }
+    c:int
+    d:double
+}
+
+service testDefinedTypeParamService(p : testParam) {
+
+    inputPort ip {
+        location:"local"
+        requestResponse: testParam(void)(void) throws TestFailed(any)
+    }
+
+    main{
+        testParam()(){
+            if (!(p instanceof testParam)){
+                throw(TestFailed, "passing argument is invalid type, expected \"testParam\"")
+            }
+        }
+    }
+}

--- a/test/primitives/private/service_node_param_optional.ol
+++ b/test/primitives/private/service_node_param_optional.ol
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Narongrit Unwerawattana <narongrit.kie@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+ 
+type testParam :int {
+    a:string
+    b:void{
+        a:int
+    }
+    c:int
+    d:double
+}
+
+type testParamOptional : testParam | undefined
+
+service testTypeOptionalParamService(p : testParamOptional) {
+
+    inputPort ip{
+        location:"local"
+        requestResponse: testParam(void)(void) throws TestFailed(any)
+    }
+
+    main{
+        testParam()(){
+            if (!(p instanceof testParamOptional)){
+                throw(TestFailed, "passing argument is invalid type, expected \"testParamOptional\"")
+            }
+        }
+    }
+}

--- a/test/primitives/private/service_node_param_string.ol
+++ b/test/primitives/private/service_node_param_string.ol
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Narongrit Unwerawattana <narongrit.kie@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+ 
+service testStringParamService(var : string) {
+
+    inputPort ip {
+        location:"local"
+        requestResponse: testParam(void)(void) throws TestFailed(any)
+    }
+
+    main{
+        testParam()(){
+            if (!is_string(var)){
+                throw(TestFailed, "passing argument is invalid type, expected \"string\"")
+            }
+        }
+    }
+}

--- a/test/primitives/service_node.ol
+++ b/test/primitives/service_node.ol
@@ -16,132 +16,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  * MA 02110-1301  USA
  */
- 
-/**
-    Test syntax
-*/
-
-service testStringParamService(var : string) {
-
-    inputPort ip {
-        location:"local"
-        requestResponse: testParam(void)(void) throws TestFailed(any)
-    }
-
-    main{
-        testParam()(){
-            if (!is_string(var)){
-                throw(TestFailed, "passing argument is invalid type, expected \"string\"")
-            }
-        }
-    }
-}
-
-
-/**
-    A service with custom type
-*/
-
-type testParam :int {
-    a:string
-    b:void{
-        a:int
-    }
-    c:int
-    d:double
-}
-
-service testDefinedTypeParamService(p : testParam) {
-
-    inputPort ip {
-        location:"local"
-        requestResponse: testParam(void)(void) throws TestFailed(any)
-    }
-
-    main{
-        testParam()(){
-            if (!(p instanceof testParam)){
-                throw(TestFailed, "passing argument is invalid type, expected \"testParam\"")
-            }
-        }
-    }
-}
-
-/**
-    A service with optional custom type
-*/
-type testParamOptional : testParam | undefined
-
-service testTypeOptionalParamService(p : testParamOptional) {
-
-    inputPort ip{
-        location:"local"
-        requestResponse: testParam(void)(void) throws TestFailed(any)
-    }
-
-    main{
-        testParam()(){
-            if (!(p instanceof testParamOptional)){
-                throw(TestFailed, "passing argument is invalid type, expected \"testParamOptional\"")
-            }
-        }
-    }
-}
-
-/**
-    Variable path node as an argument
-*/
-
-type parenParam: void{
-    a : string
-    child :childParam 
-}
-
-type childParam : void{
-    a : string
-    b : int
-}
-
-service ParentService(p : parenParam) {
-
-    inputPort ip {
-        location:"local"
-        requestResponse: testParam(void)(void) throws TestFailed(any)
-    }
-
-    embed ChildService(p.child) as Child
-
-    main{
-        testParam()(){
-            if (!(p instanceof parenParam)){
-                throw(TestFailed, "passing argument is invalid type, expected \"parenParam\"")
-            }
-            testParam@Child()()
-        }
-    }
-}
-
-service ChildService(p : childParam) {
-
-    inputPort ip {
-        location:"local"
-        requestResponse: testParam(void)(void) throws TestFailed(any)
-    }
-
-    main{
-        testParam()(){
-            if (!(p instanceof childParam)){
-                throw(TestFailed, "passing argument is invalid type, expected \"childParam\"")
-            }
-        }
-    }
-}
-
 
 /**
     test import an embedded service node
 */
 from .private.service_node_mul import MulService
+from .private.service_node_param_string import testStringParamService
+from .private.service_node_param_custom import testDefinedTypeParamService
+from .private.service_node_param_optional import testTypeOptionalParamService
+from .private.service_node_multi_services import ParentService
 
 
 interface TestUnitInterface {

--- a/tools/jolie2dummy/src/main/java/joliex/dummycreator/JolieDummyCreator.java
+++ b/tools/jolie2dummy/src/main/java/joliex/dummycreator/JolieDummyCreator.java
@@ -51,7 +51,8 @@ public class JolieDummyCreator {
 				cmdParser.getInterpreterConfiguration().includePaths(),
 				cmdParser.getInterpreterConfiguration().packagePaths(),
 				cmdParser.getInterpreterConfiguration().jolieClassLoader(),
-				cmdParser.getInterpreterConfiguration().constants(), false );
+				cmdParser.getInterpreterConfiguration().constants(),
+				cmdParser.getInterpreterConfiguration().executionTarget(), false );
 			ProgramInspector inspector = ParsingUtils.createInspector( program );
 			JolieDummyDocumentCreator document =
 				new JolieDummyDocumentCreator( inspector, cmdParser.getInterpreterConfiguration().programFilepath() );

--- a/tools/jolie2java/src/main/java/joliex/java/Jolie2Java.java
+++ b/tools/jolie2java/src/main/java/joliex/java/Jolie2Java.java
@@ -36,7 +36,8 @@ public class Jolie2Java {
 				cmdParser.getInterpreterConfiguration().includePaths(),
 				cmdParser.getInterpreterConfiguration().packagePaths(),
 				cmdParser.getInterpreterConfiguration().jolieClassLoader(),
-				cmdParser.getInterpreterConfiguration().constants(), false );
+				cmdParser.getInterpreterConfiguration().constants(),
+				cmdParser.getInterpreterConfiguration().executionTarget(), false );
 
 			ProgramInspector inspector = ParsingUtils.createInspector( program );
 

--- a/tools/jolie2java/src/test/java/joliex/java/impl/JavaDocumentCreatorTest.java
+++ b/tools/jolie2java/src/test/java/joliex/java/impl/JavaDocumentCreatorTest.java
@@ -100,6 +100,7 @@ public class JavaDocumentCreatorTest {
 			cmdParser.getInterpreterConfiguration().packagePaths(),
 			cmdParser.getInterpreterConfiguration().jolieClassLoader(),
 			cmdParser.getInterpreterConfiguration().constants(),
+			cmdParser.getInterpreterConfiguration().executionTarget(),
 			false );
 
 		// Program program = parser.parse();

--- a/tools/jolie2java/src/test/java/joliex/java/impl/OutputDirectoryTest.java
+++ b/tools/jolie2java/src/test/java/joliex/java/impl/OutputDirectoryTest.java
@@ -65,6 +65,7 @@ public class OutputDirectoryTest {
 			cmdParser.getInterpreterConfiguration().packagePaths(),
 			cmdParser.getInterpreterConfiguration().jolieClassLoader(),
 			cmdParser.getInterpreterConfiguration().constants(),
+			cmdParser.getInterpreterConfiguration().executionTarget(),
 			false );
 
 		// Program program = parser.parse();
@@ -88,6 +89,7 @@ public class OutputDirectoryTest {
 			cmdParser.getInterpreterConfiguration().packagePaths(),
 			cmdParser.getInterpreterConfiguration().jolieClassLoader(),
 			cmdParser.getInterpreterConfiguration().constants(),
+			cmdParser.getInterpreterConfiguration().executionTarget(),
 			false );
 
 		// Program program = parser.parse();

--- a/tools/jolie2plasma/src/main/java/joliex/plasma/Jolie2Plasma.java
+++ b/tools/jolie2plasma/src/main/java/joliex/plasma/Jolie2Plasma.java
@@ -59,6 +59,7 @@ public class Jolie2Plasma {
 					cmdParser.getInterpreterConfiguration().packagePaths(),
 					cmdParser.getInterpreterConfiguration().jolieClassLoader(),
 					cmdParser.getInterpreterConfiguration().constants(),
+					cmdParser.getInterpreterConfiguration().executionTarget(),
 					false );
 				new InterfaceConverter(
 					program,

--- a/tools/jolie2surface/src/main/java/joliex/surface/GetSurface.java
+++ b/tools/jolie2surface/src/main/java/joliex/surface/GetSurface.java
@@ -51,7 +51,9 @@ public class GetSurface {
 				cmdParser.getInterpreterConfiguration().includePaths(),
 				cmdParser.getInterpreterConfiguration().packagePaths(),
 				cmdParser.getInterpreterConfiguration().jolieClassLoader(),
-				cmdParser.getInterpreterConfiguration().constants(), false );
+				cmdParser.getInterpreterConfiguration().constants(),
+				cmdParser.getInterpreterConfiguration().executionTarget(),
+				false );
 			ProgramInspector inspector = ParsingUtils.createInspector( program );
 			SurfaceCreator document = new SurfaceCreator( inspector );
 			document.ConvertDocument( cmdParser.getInterpreterConfiguration().arguments()[ 0 ],

--- a/tools/jolie2wsdl/src/main/java/joliex/wsdl/Jolie2Wsdl.java
+++ b/tools/jolie2wsdl/src/main/java/joliex/wsdl/Jolie2Wsdl.java
@@ -29,7 +29,9 @@ public class Jolie2Wsdl {
 				cmdParser.getInterpreterConfiguration().includePaths(),
 				cmdParser.getInterpreterConfiguration().packagePaths(),
 				cmdParser.getInterpreterConfiguration().jolieClassLoader(),
-				cmdParser.getInterpreterConfiguration().constants(), false );
+				cmdParser.getInterpreterConfiguration().constants(),
+				cmdParser.getInterpreterConfiguration().executionTarget(),
+				false );
 
 			// Program program = parser.parse();
 			ProgramInspector inspector = ParsingUtils.createInspector( program );

--- a/tools/joliec/src/main/java/jolie/compiler/Compiler.java
+++ b/tools/joliec/src/main/java/jolie/compiler/Compiler.java
@@ -54,7 +54,9 @@ public class Compiler {
 			cmdParser.getInterpreterConfiguration().includePaths(),
 			cmdParser.getInterpreterConfiguration().packagePaths(),
 			cmdParser.getInterpreterConfiguration().jolieClassLoader(),
-			cmdParser.getInterpreterConfiguration().constants(), false );
+			cmdParser.getInterpreterConfiguration().constants(),
+			cmdParser.getInterpreterConfiguration().executionTarget(),
+			false );
 		// GZIPOutputStream gzipstream = new GZIPOutputStream( ostream );
 		ObjectOutputStream oos = new ObjectOutputStream( ostream );
 		oos.writeObject( program );


### PR DESCRIPTION

When executing `jolie hello.ol`. The following cases are considered.
1. if there is exactly one service defined in hello.ol, that's the one we launch for the target execution.
(we ignore the imported services)
2. if there are multiple services defined in hello.ol, then there is no default, the programmer MUST specify the service name.

Specifying a target service can be done through command line flag --service or -s for short. e.g.
```
jolie --service HelloService hello.ol
```

Where HelloService is one of the defined services in hello.ol.