### PR TITLE
optimize link type symbol resolution

### DIFF
--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
@@ -567,6 +567,9 @@ public class SymbolReferenceResolver {
 					return;
 				}
 				linkedType = (TypeDefinition) targetSymbolInfo.get().node();
+				while( linkedType instanceof TypeDefinitionLink ) {
+					linkedType = ((TypeDefinitionLink) linkedType).linkedType();
+				}
 				if( linkedType.equals( n ) ) {
 					error( buildSymbolNotFoundError( n, n.id() ) );
 					return;

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
@@ -157,6 +157,11 @@ public class SymbolReferenceResolver {
 			+ " service doesn't have an inputPort with location 'local' defined." );
 	}
 
+	private static CodeCheckingError buildTypeLinkOutOfBoundError( TypeDefinitionLink node ) {
+		return CodeCheckingError.build( node, "Unable to find linked type: " + node.name()
+			+ " has infinite loop to it's linked type" );
+	}
+
 	private class SymbolReferenceResolverVisitor implements OLVisitor {
 		private URI currentURI;
 		private final List< CodeCheckingError > errors = new ArrayList<>();
@@ -567,8 +572,14 @@ public class SymbolReferenceResolver {
 					return;
 				}
 				linkedType = (TypeDefinition) targetSymbolInfo.get().node();
+				int linkCounter = 0;
 				while( linkedType instanceof TypeDefinitionLink ) {
+					if( linkCounter == 100 ) {
+						error( buildTypeLinkOutOfBoundError( n ) );
+						return;
+					}
 					linkedType = ((TypeDefinitionLink) linkedType).linkedType();
+					linkCounter++;
 				}
 				if( linkedType.equals( n ) ) {
 					error( buildSymbolNotFoundError( n, n.id() ) );


### PR DESCRIPTION
Resolving a link type symbol to the root of the linking chain, instead of resolving to one level upper.