### PR TITLE
porting standard library to service syntax

### DIFF
--- a/libjolie/src/main/java/jolie/lang/parse/OLParser.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParser.java
@@ -1979,9 +1979,13 @@ public class OLParser extends AbstractParser {
 							nextToken();
 							eat( Scanner.TokenType.RPAREN, "expected )" );
 						}
-						TypeDefinition faultType = definedTypes.getOrDefault( faultTypeName,
-							new TypeDefinitionLink( getContext(), faultTypeName,
-								Constants.RANGE_ONE_TO_ONE, faultTypeName ) );
+						TypeDefinition faultType = new TypeDefinitionLink( getContext(), faultTypeName,
+							Constants.RANGE_ONE_TO_ONE, faultTypeName );
+						if( definedTypes.containsKey( faultTypeName ) ) {
+							faultType = definedTypes.get( faultTypeName );
+						} else {
+							definedTypes.put( faultTypeName, faultType );
+						}
 						faultTypesMap.put( faultName, faultType );
 					}
 				}

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
@@ -567,6 +567,9 @@ public class SymbolReferenceResolver {
 					return;
 				}
 				linkedType = (TypeDefinition) targetSymbolInfo.get().node();
+				while( linkedType instanceof TypeDefinitionLink ) {
+					linkedType = ((TypeDefinitionLink) linkedType).linkedType();
+				}
 				if( linkedType.equals( n ) ) {
 					error( buildSymbolNotFoundError( n, n.id() ) );
 					return;

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
@@ -151,9 +151,7 @@ public class SymbolTableGenerator {
 			decl.requestType().accept( this );
 			decl.responseType().accept( this );
 			for( Map.Entry< String, TypeDefinition > fault : decl.faults().entrySet() ) {
-				if( this.symbolTable.getSymbol( fault.getValue().id() ) == null ) {
-					fault.getValue().accept( this );
-				}
+				fault.getValue().accept( this );
 			}
 		}
 
@@ -356,7 +354,9 @@ public class SymbolTableGenerator {
 		@Override
 		public void visit( TypeDefinitionLink n ) {
 			try {
-				this.symbolTable.addSymbol( n.id(), n );
+				if( !this.symbolTable.getSymbol( n.id() ).isPresent() ) {
+					this.symbolTable.addSymbol( n.id(), n );
+				}
 			} catch( DuplicateSymbolException e ) {
 				this.valid = false;
 				this.error = new ModuleException( n.context(), e );

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
@@ -151,7 +151,9 @@ public class SymbolTableGenerator {
 			decl.requestType().accept( this );
 			decl.responseType().accept( this );
 			for( Map.Entry< String, TypeDefinition > fault : decl.faults().entrySet() ) {
-				fault.getValue().accept( this );
+				if( this.symbolTable.getSymbol( fault.getValue().id() ) == null ) {
+					fault.getValue().accept( this );
+				}
 			}
 		}
 

--- a/packages/bluetooth.ol
+++ b/packages/bluetooth.ol
@@ -1,0 +1,54 @@
+/*
+ *   Copyright (C) 2008 by Fabrizio Montesi <famontesi@gmail.com>         
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+
+type BluetoothInquiryResponse:void {
+	.device[0,*]:void {
+		.address:string
+		.name:string
+	}
+	.service[0,*]:void {
+		.location:string
+	}
+}
+
+interface BluetoothInterface {
+RequestResponse:
+	/**!
+	 * Sets the current Bluetooth device as discoverable or not discoverable
+	 * @request: 0 if the device has to be set not discoverable, 1 if the device has to be set discoverable.
+	 */
+	setDiscoverable(int)(int),
+	inquire(void)(BluetoothInquiryResponse)
+	//discoveryServices
+}
+
+
+service Bluetooth {
+    inputPort ip {
+        location:"local"
+        interfaces: BluetoothInterface
+    }
+
+    foreign java {
+        class: "joliex.net.BluetoothService"
+    }
+}

--- a/packages/converter.ol
+++ b/packages/converter.ol
@@ -1,0 +1,52 @@
+/*
+ *   Copyright (C) 2015 by Matthias Dieter Wallnöfer                      
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+from types.IOException import IOExceptionType
+
+/** The byte array to be converted */
+type RawToStringRequest:raw {
+	.charset?:string //< set the encoding. Default: system (eg. for Unix-like OS UTF-8)
+}
+
+type StringToRawRequest:string {
+	.charset?:string //< set the encoding. Default: system (eg. for Unix-like OS UTF-8)
+}
+
+interface ConverterInterface {
+RequestResponse:
+	rawToBase64( raw )( string ),
+	base64ToRaw( string )( raw ) throws IOException(IOExceptionType),
+
+	/** string <-> raw (byte arrays) conversion methods */
+	rawToString( RawToStringRequest )( string ) throws IOException(IOExceptionType),
+	stringToRaw( StringToRawRequest )( raw ) throws IOException(IOExceptionType)
+}
+
+service Converter {
+    inputPort ip {
+        location:"local"
+        interfaces: ConverterInterface
+    }
+
+    foreign java {
+        class: "joliex.util.Converter"
+    }
+}

--- a/packages/database.ol
+++ b/packages/database.ol
@@ -1,0 +1,149 @@
+/*
+ *   Copyright (C) 2008 by Fabrizio Montesi <famontesi@gmail.com>         
+ *   Copyright (C) 2015 by Matthias Dieter Wallnöfer                      
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+type ConnectionInfo:void {
+	.driver:string // http://docs.jolie-lang.org/#!documentation/databases/databases.html
+	.host:string
+	.port?:int
+	.database:string
+	.username:string
+	.password:string
+	.attributes?:string // further semicolon-separated JDBC connection string parameters
+	.checkConnection?:int // if true (> 0) check connection before each DB command (default: false (0))
+	.toLowerCase?: bool // lowercase attribute names
+	.toUpperCase?: bool // uppercase attribute names
+}
+
+type QueryResult:void {
+	.row[0,*]:void { ? }
+}
+
+type TransactionQueryResult:int {
+	.row[0,*]:void { ? }
+}
+
+type DatabaseTransactionRequest:void {
+	.statement[1,*]:string { ? }
+}
+
+type DatabaseTransactionResult:void {
+	.result[0,*]:TransactionQueryResult
+}
+
+type QueryRequest:string { ? }
+
+type UpdateRequest:string { ? }
+
+interface DatabaseInterface {
+RequestResponse:
+	/**!
+	 * Connects to a database and eventually closes a previous connection
+	 *
+	 * Example with HSQLDB:
+	 * with ( connectionInfo ) {
+	 *     .username = "sa";
+	 *     .password = "";
+	 *     .host = "";
+	 *     .database = "file:weatherdb/weatherdb"; // "." for memory-only
+	 *     .driver = "hsqldb_embedded"
+	 * };
+	 * connect@Database( connectionInfo )( void );
+	 */
+	connect(ConnectionInfo)(void) throws ConnectionError InvalidDriver DriverClassNotFound,
+	/**!
+	 * Explicitly closes a database connection
+	 * Per default the close happens on reconnect or on termination of the
+	 * Database service, eg. when the enclosing program finishes.
+	 */
+	close(void)(void),
+	
+	/**!
+	 * Queries the database and returns a result set
+	 *
+	 * Example with SQL parameters:
+	 * queryRequest =
+	 *     "SELECT city, country, data FROM weather " +
+	 *     "WHERE city=:city AND country=:country";
+	 * queryRequest.city = City;
+	 * queryRequest.country = Country;
+	 * query@Database( queryRequest )( queryResponse );
+	 *
+	 * _template:
+	 * Field _template allows for the definition of a specific output template.
+	 * Assume, e.g., to have a table with the following columns:
+	 * | col1 | col2 | col3 | col4 |
+	 * If _template is not used the output will be rows with the following format:
+	 * row
+	 *  |-col1
+	 *  |-col2
+	 *  |-col3
+	 *  |-col4
+	 * Now let us suppose we would like to have the following structure for each row:
+	 * row
+	 *   |-mycol1			contains content of col1
+	 *       |-mycol2		contains content of col2
+	 * 	 |-mycol3		contains content of col3
+	 *   |-mycol4			contains content of col4
+	 *
+	 * In order to achieve this, we can use field _template as it follows:
+	 *   with( query_request._template ) {
+	 *     .mycol1 = "col1";
+	 *     .mycol1.mycol2 = "col2";
+	 *     .mycol1.mycol2.mycol3 = "col3";
+	 *     .mycol4 = "col4"
+	 *   }
+	 * _template does not currently support vectors.
+	 */
+	query(QueryRequest)(QueryResult) throws SQLException ConnectionError,
+	/**!
+	 * Updates the database and returns a single status code
+	 *
+	 * Example with SQL parameters:
+	 * updateRequest =
+	 *     "INSERT INTO weather(city, country, data) " +
+	 *     "VALUES (:city, :country, :data)";
+	 * updateRequest.city = City;
+	 * updateRequest.country = Country;
+	 * updateRequest.data = r;
+	 * update@Database( updateRequest )( ret )
+	 */
+	update(UpdateRequest)(int) throws SQLException ConnectionError,
+	/**!
+	 * Checks the connection with the database. Throws ConnectionError if the connection is not functioning properly.
+	 */
+	checkConnection( void )( void ) throws ConnectionError,
+	/**!
+	 * Executes more than one database command in a single transaction
+	 */
+	executeTransaction(DatabaseTransactionRequest)(DatabaseTransactionResult) throws SQLException ConnectionError
+}
+
+service Database {
+    inputPort ip {
+        location:"local"
+        interfaces: DatabaseInterface
+    }
+
+    foreign java {
+        class: "joliex.db.DatabaseService"
+    }
+}

--- a/packages/exec.ol
+++ b/packages/exec.ol
@@ -1,0 +1,49 @@
+/*
+ *   Copyright (C) 2008 by Fabrizio Montesi <famontesi@gmail.com>         
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+
+type CommandExecutionRequest:string { // The command to execute
+	.waitFor?:int // 1 if the command is to be waited for, 0 otherwise
+	.args[0,*]:string // Arguments to be passed to the command
+	.workingDirectory?:string // Working directory for the process to execute (default: current directory)
+	.stdOutConsoleEnable?: bool // if true standard output is redirected to console
+}
+
+type CommandExecutionResult:any { // Can be string or void
+	.exitCode?:int // The exit code of the executed command
+	.stderr?:string // The standard error output of the executed command
+}
+
+interface ExecInterface {
+	RequestResponse:
+		exec(CommandExecutionRequest)(CommandExecutionResult)
+}
+
+service Exec {
+    inputPort ip {
+        location:"local"
+        interfaces: ExecInterface
+    }
+
+    foreign java {
+        class: "joliex.util.ExecService"
+    }
+}

--- a/packages/file.ol
+++ b/packages/file.ol
@@ -1,0 +1,214 @@
+/*
+ *   Copyright (C) 2008 by Fabrizio Montesi <famontesi@gmail.com>          
+ *                                                                         
+ *   This program is free software; you can redistribute it and/or modify  
+ *   it under the terms of the GNU Library General Public License as       
+ *   published by the Free Software Foundation; either version 2 of the    
+ *   License, or (at your option) any later version.                       
+ *                                                                         
+ *   This program is distributed in the hope that it will be useful,       
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         
+ *   GNU General Public License for more details.                          
+ *                                                                         
+ *   You should have received a copy of the GNU Library General Public     
+ *   License along with this program; if not, write to the                 
+ *   Free Software Foundation, Inc.,                                       
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             
+ *                                                                         
+ *   For details about the authors of this software, see the AUTHORS file. 
+ */
+
+from types.JavaException import JavaExceptionType, WeakJavaExceptionType
+from types.IOException import *
+
+type FileNotFoundType:WeakJavaExceptionType
+
+/**!
+from: the source directory to copy
+to: the target directory to copy into
+*/
+type CopyDirRequest: void {
+	.from: string
+	.to: string
+}
+
+type ReadFileRequest {
+	filename:string
+	format?:string { // "text" (default), "base64" (same as "binary" but afterwards base64-encoded), "binary", "xml" (a type-annotated XML format), "xml_store", "properties" (Java properties file) or "json"
+		charset?:string // set the encoding. Default: system (eg. for Unix-like OS UTF-8), header specification (XML) or format's default (for XML and JSON UTF-8)
+		skipMixedText?: bool // in case of format xml, it skips the mixed elements
+	}
+}
+
+type WriteFileRequest:void {
+	.filename:string
+	.content:undefined
+	.format?:string { // "text", "binary", "xml", "xml_store" (a type-annotated XML format) or "json" (defaults to "binary" if contents' base value is raw, "text" otherwise)
+		.doctype_system?:string // If format is "xml", adds it as a DOCTYPE system tag
+		.schema*:string
+		.indent?:bool // if true, indentation is applied to file (default: false)
+		.encoding?:string // set the encoding. Default: system (eg. for Unix-like OS UTF-8) or format's default (for XML and JSON UTF-8)
+	}
+	.append?:int // Default: 0
+}
+
+type DeleteRequest:string { // The filename to delete
+	.isRegex?:int // 1 if the filename is a regular expression, 0 otherwise
+}
+
+type RenameRequest:void {
+	.filename:string
+	.to:string
+}
+
+type ListRequest:void {
+	.directory:string
+	.regex?:string
+	.recursive?:bool
+	.dirsOnly?:bool	// List only directories?
+	.order?: void {
+		.byname?: bool
+	}
+	.info?: bool // it returns also file infos. Default is false
+}
+
+type ListResponse:void {
+	.result[0,*]:string {
+		.info?: void {
+			.lastModified: long
+			.size: long
+			.absolutePath: string
+			.isHidden: bool
+			.isDirectory: bool
+		}
+	}
+}
+
+interface FileInterface {
+RequestResponse:
+	/**!
+	 * Constructs an absolute path to the target file or directory.
+	 * Can be used to construct an absolute path for new files that does not exist yet.
+	 * Throws a InvalidPathException fault if input is a relative path is not system recognized path.
+	 */
+	toAbsolutePath( string )( string ) throws InvalidPathException( JavaExceptionType ),
+
+	/**!
+	 * Constructs the path to the parent directory.
+	 * Can be used to construct paths that does not exist so long as the path uses the system's filesystem path conventions.
+	 * Throws a InvalidPathException fault if input path is not a recognized system path or if the parent has no parent.
+	 */
+	getParentPath( string )( string ) throws InvalidPathException( JavaExceptionType ),
+
+	/**!
+	  it returns if a filename is a directory or not. False if the file does not exist.
+	*/
+	isDirectory( string )( bool ) throws FileNotFound(FileNotFoundType) IOException(IOExceptionType),
+
+	/**!
+	 * Reads some file's content into a Jolie structure
+	 *
+	 * Supported formats (ReadFileRequest.format):
+	 * - text (the default)
+	 * - base64 (same as binary but afterwards base64-encoded)
+	 * - binary
+	 * - xml
+	 * - xml_store (a type-annotated XML format)
+	 * - properties (Java properties file)
+	 * - json
+	 *
+	 * Child values: text, base64 and binary only populate the return's base value, the other formats fill in the child values as well.
+	 * - xml, xml_store: the XML root node will costitute a return's child value, the rest is filled in recursively
+	 * - properties: each property is represented by a child value
+	 * - json: each attribute corresponds to a child value, the default values (attribute "$" or singular value) are saved as the base values, nested arrays get mapped with the "_" helper childs (e.g. a[i][j] -> a._[i]._[j]), the rest is filled in recursively
+	 */
+	readFile(ReadFileRequest)(undefined)
+		throws FileNotFound(FileNotFoundType) IOException(IOExceptionType),
+
+	/**!
+	 * Writes a Jolie structure out to an external file
+	 *
+	 * Supported formats (WriteFileRequest.format):
+	 * - text (the default if base value not of type raw)
+	 * - binary (the default if base value of type raw)
+	 * - xml
+	 * - xml_store (a type-annotated XML format)
+	 * - json
+	 *
+	 *
+	 * Child values: text and binary only consider the content's (WriteFileRequest.content) base value, the other formats look at the child values as well.
+	 * - xml, xml_store: the XML root node will costitute the content's only child value, the rest gets read out recursively
+	 * - json: each child value corresponds to an attribute, the base values are saved as the default values (attribute "$" or singular value), the "_" helper childs disappear (e.g. a._[i]._[j] -> a[i][j]), the rest gets read out recursively
+	 *
+	 *	when format is xml and a schema is defined, the resulting xml follows the schema constraints.
+	 *  Use "@NameSpace" in order to enable root element identification in the schema by specifing the namespace of the root.
+	 *  Use "@Prefix" for forcing a prefix in an element.
+	 *  Use "@ForceAttribute" for forcing an attribute in an element even if it is not defined in the corresponding schema
+	 */
+	writeFile(WriteFileRequest)(void) throws FileNotFound(FileNotFoundType) IOException(IOExceptionType),
+
+	/**!
+	  it copies a source directory into a destination one
+	*/
+	copyDir( CopyDirRequest )( bool ) throws IOException FileNotFound,
+
+	delete(DeleteRequest)(bool) throws IOException(IOExceptionType),
+
+	/**!
+	   it deletes a directory recursively removing all its contents
+	*/
+	deleteDir( string )( bool ) throws IOException(IOExceptionType),
+
+	/**!
+	 * The size of any basic type variable.
+	 * - raw: buffer size
+	 * - void: 0
+	 * - boolean: 1
+	 * - integer types: int 4, long 8
+	 * - double: 8
+	 * - string: size in the respective platform encoding, on ASCII and latin1
+	 *   equal to the string's length, on Unicode (UTF-8 etc.) >= string's length
+	 */
+	getSize( any )( int ),
+
+	rename(RenameRequest)(void) throws IOException(IOExceptionType),
+	list(ListRequest)(ListResponse) throws IOException(IOExceptionType),
+	/**!
+	*
+	* it creates the directory specified in the request root. Returns true if the directory has been
+	* created with success, false otherwise
+	*/
+	mkdir( string )( bool ),
+
+	/**!
+	* it tests if the specified file or directory exists or not.
+	*/
+	exists( string )( bool ),
+
+	/** Returns the parent path of the service */
+	getServiceParentPath(void)(string),
+
+	/** Returns the filesystem directory from which the service has been launched */
+	getServiceDirectory(void)(string) throws IOException(IOExceptionType),
+	getFileSeparator(void)(string),
+	getMimeType(string)(string) throws FileNotFound(FileNotFoundType),
+	setMimeTypeFile(string)(void) throws IOException(IOExceptionType),
+
+	/**! deprecated, please use rawToBase64@Converter()() from converter.iol */
+	convertFromBinaryToBase64Value( raw )( string ),
+	/**! deprecated, please use base64ToRaw@Converter()() from converter.iol */
+	convertFromBase64ToBinaryValue( string )( raw ) throws IOException(IOExceptionType)
+
+}
+
+service File {
+    inputPort ip {
+        location:"local"
+        interfaces: FileInterface
+    }
+
+    foreign java {
+        class: "joliex.io.FileService"
+    }
+}

--- a/packages/file.ol
+++ b/packages/file.ol
@@ -20,7 +20,7 @@
  */
 
 from types.JavaException import JavaExceptionType, WeakJavaExceptionType
-from types.IOException import *
+from types.IOException import IOExceptionType
 
 type FileNotFoundType:WeakJavaExceptionType
 

--- a/packages/html_utils.ol
+++ b/packages/html_utils.ol
@@ -1,0 +1,38 @@
+/*
+ *   Copyright (C) 2011 by Claudio Guidi <cguidi@italianasoftare.com>
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as
+ *   published by the Free Software Foundation; either version 2 of the
+ *   License, or (at your option) any later version
+ *
+ *   This program is distributed in the hope that it will be useful
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the
+ *   Free Software Foundation, Inc
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ *   For details about the authors of this software, see the AUTHORS file
+ */
+
+
+interface HTMLUtilsInterface {
+RequestResponse:
+	unescapeHTML( string )( string ),
+	escapeHTML( string )( string )
+}
+
+service HTMLUtils {
+    inputPort ip {
+        location:"local"
+        interfaces: HTMLUtilsInterface
+    }
+
+    foreign java {
+        class: "joliex.util.HTMLUtils"
+    }
+}

--- a/packages/ini_utils.ol
+++ b/packages/ini_utils.ol
@@ -1,0 +1,42 @@
+/*
+ *   Copyright (C) 2009 by Fabrizio Montesi <famontesi@gmail.com>         
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+type parseIniFileRequest:string {
+	.charset?:string // set the encoding. Default: system (eg. for Unix-like OS UTF-8)
+}
+
+type IniData:void { ? }
+
+interface IniUtilsInterface {
+RequestResponse:
+	parseIniFile(parseIniFileRequest)(IniData)
+}
+
+service IniUtils {
+    inputPort ip {
+        location:"local"
+        interfaces: IniUtilsInterface
+    }
+
+    foreign java {
+        class: "joliex.util.IniUtils"
+    }
+}

--- a/packages/inspector.ol
+++ b/packages/inspector.ol
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2019 Saverio Giallorenzo <saverio.giallorenzo@gmail.com>
+ * Copyright (C) 2019 Fabrizio Montesi <famontesi@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+from types.JavaException import *
+
+type Field {
+	name: string
+	range {
+		min:int
+		max:int
+	}
+	type: TypeInfo
+}
+
+type TypeInfo:
+void {
+	documentation?: string
+	linkedTypeName: string
+}
+|
+// Inline type definition
+void {
+	documentation?: string
+	nativeType: string
+	fields*: Field
+	untypedFields: bool
+}
+|
+// Type choice
+void {
+	documentation?: string
+	left: TypeInfo
+	right: TypeInfo
+}
+
+type FaultInfo {
+	name: string
+	type: string
+}
+
+type OperationInfo {
+	name: string
+	requestType: string
+	responseType?: string
+	faults*: FaultInfo
+	documentation?: string
+}
+
+type InterfaceInfo {
+	name: string
+	operations*: OperationInfo
+	documentation?: string
+}
+
+type PortInfo {
+	name: string
+	location?: string
+	protocol?: string
+	interfaces*: InterfaceInfo
+	documentation?: string
+}
+
+type TypeDefinition {
+	name: string
+	type: TypeInfo
+}
+
+type PortInspectionResponse {
+	inputPorts*: PortInfo
+	outputPorts*: PortInfo
+	referredTypes*: TypeDefinition
+}
+
+type TypesInspectionResponse {
+	types*: TypeDefinition
+}
+
+type InspectionRequest {
+	filename: string
+	includePaths*: string
+	source?: string
+}
+
+interface InspectorInterface {
+RequestResponse:
+	inspectPorts( InspectionRequest )( PortInspectionResponse )
+		throws	ParserException( WeakJavaExceptionType )
+						SemanticException( WeakJavaExceptionType )
+						FileNotFoundException( WeakJavaExceptionType )
+						IOException( WeakJavaExceptionType ),
+	inspectTypes( InspectionRequest )( TypesInspectionResponse )
+		throws	ParserException( WeakJavaExceptionType )
+						SemanticException( WeakJavaExceptionType )
+						FileNotFoundException( WeakJavaExceptionType )
+						IOException( WeakJavaExceptionType )
+}
+
+service Inspector {
+    inputPort ip {
+        location:"local"
+        interfaces: InspectorInterface
+    }
+
+    foreign java {
+        class: "joliex.lang.inspector.Inspector"
+    }
+}

--- a/packages/json_utils.ol
+++ b/packages/json_utils.ol
@@ -1,0 +1,60 @@
+/*
+ *   Copyright (C) 2013 by Claudio Guidi                                  
+ *   Copyright (C) 2015 by Matthias Dieter Wallnöfer                      
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+type GetJsonStringRequest: undefined
+type GetJsonStringResponse: string
+
+type GetJsonValueRequest: any {
+	.strictEncoding?: bool
+	.charset?:string // set the encoding. Default: system (eg. for Unix-like OS UTF-8) or header specification
+}
+type GetJsonValueResponse: undefined
+
+interface JsonUtilsInterface {
+RequestResponse:
+	/**!
+	 * Returns the value converted into a JSON string
+	 *
+	 * Each child value corresponds to an attribute, the base values are saved as the default values (attribute "$" or singular value), the "_" helper childs disappear (e.g. a._[i]._[j] -> a[i][j]), the rest gets converted recursively
+	 */
+	getJsonString( GetJsonStringRequest )( GetJsonStringResponse )
+	      throws JSONCreationError,
+
+	/**!
+	 * Returns the JSON string converted into a value
+	 *
+	 * Each attribute corresponds to a child value, the default values (attribute "$" or singular value) are saved as the base values, nested arrays get mapped with the "_" helper childs (e.g. a[i][j] -> a._[i]._[j]), the rest gets converted recursively
+	 */
+	getJsonValue( GetJsonValueRequest )( GetJsonValueResponse )
+	      throws JSONCreationError
+}
+
+service JsonUtils {
+    inputPort ip {
+        location:"local"
+        interfaces: JsonUtilsInterface
+    }
+
+    foreign java {
+        class: "joliex.util.JsonUtilsService"
+    }
+}

--- a/packages/math.ol
+++ b/packages/math.ol
@@ -1,0 +1,65 @@
+/*
+ *   Copyright (C) 2009-2016 by Fabrizio Montesi <famontesi@gmail.com>    
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+type RoundRequestType:double {
+	.decimals?:int
+}
+
+type PowRequest:void {
+	.base:double
+	.exponent:double
+}
+
+type SummationRequest:void {
+	.from:int
+	.to:int
+}
+
+interface MathInterface {
+RequestResponse:
+	/**! Returns the absolute value of the input integer. */
+	abs(int)(int),
+
+	/**! Returns a random number d such that 0.0 <= d < 1.0. */
+	random(void)(double),
+
+	/**! Returns the PI constant */
+	pi(void)(double),
+
+	round(RoundRequestType)(double),
+
+	/**! Returns the result of .base to the power of .exponent (see request data type). */
+	pow(PowRequest)(double),
+
+	/**! Returns the summation of values from .from to .to (see request data type). For example, .from=2 and .to=5 would produce a return value of 2+3+4+5=14. */
+	summation(SummationRequest)(int)
+}
+
+service Math {
+    inputPort ip {
+        location:"local"
+        interfaces: MathInterface
+    }
+
+    foreign java {
+        class: "joliex.util.MathService"
+    }
+}

--- a/packages/message_digest.ol
+++ b/packages/message_digest.ol
@@ -1,0 +1,43 @@
+/*
+ *   Copyright (C) 2009 by Fabrizio Montesi <famontesi@gmail.com>         
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+from types.JavaException import *
+type MD5Request:string {
+	.radix?:int
+} | raw {
+	.radix?:int
+}
+
+interface MessageDigestInterface {
+	RequestResponse:
+		md5(MD5Request)(string) throws UnsupportedOperation(JavaExceptionType)
+}
+
+service MessageDigest {
+    inputPort ip {
+        location:"local"
+        interfaces: MessageDigestInterface
+    }
+
+    foreign java {
+        class: "joliex.security.MessageDigestService"
+    }
+}

--- a/packages/network_service.ol
+++ b/packages/network_service.ol
@@ -1,0 +1,57 @@
+/*
+ *   Copyright (C) 2012 by Claudio Guidi <cguidi@italianasoftware.com>    
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+type GetNetworkInterfaceNamesRequest: void 
+
+type GetNetworkInterfaceNamesResponse: void {
+  .interfaceName*: string {
+	.displayName: string
+  }
+}
+
+type GetIPAddressesRequest: void {
+  .interfaceName: string
+}
+
+type GetIPAddressesResponse: void {
+  .ip4?: string
+  .ip6?: string
+}
+
+
+interface NetworkServiceInterface {
+RequestResponse:
+  getNetworkInterfaceNames( GetNetworkInterfaceNamesRequest )( GetNetworkInterfaceNamesResponse ),
+  getIPAddresses( GetIPAddressesRequest )( GetIPAddressesResponse )
+    throws InterfaceNotFound
+	
+}
+
+service Network {
+    inputPort ip {
+        location:"local"
+        interfaces: NetworkServiceInterface
+    }
+
+    foreign java {
+        class: "joliex.util.NetworkService"
+    }
+}

--- a/packages/queue_utils.ol
+++ b/packages/queue_utils.ol
@@ -1,0 +1,57 @@
+/*
+ *   Copyright (C) 2013 by Saverio Giallorenzo <saverio.giallorenzo@gmail.com>
+ *                                                                         	
+ *   This program is free software; you can redistribute it and/or modify  	
+ *   it under the terms of the GNU Library General Public License as       	
+ *   published by the Free Software Foundation; either version 2 of the    	
+ *   License, or (at your option) any later version.                       	
+ *                                                                         	
+ *   This program is distributed in the hope that it will be useful,       	
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        	
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         	
+ *   GNU General Public License for more details.                          	
+ *                                                                         	
+ *   You should have received a copy of the GNU Library General Public     	
+ *   License along with this program; if not, write to the                 	
+ *   Free Software Foundation, Inc.,                                       	
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             	
+ *                                                                         	
+ *   For details about the authors of this software, see the AUTHORS file. 	
+ */
+
+type QueueRequest: void {
+	.queue_name: string
+	.element: undefined
+}
+
+interface QueueUtilsInterface {
+RequestResponse:
+	///Creates a new queue with queue_name as key
+	new_queue( string )( bool ),
+
+	///Removes an existing queue
+	delete_queue( string )( bool ),
+
+	///Pushes an element at the end of an existing queue
+	push( QueueRequest )( bool ),
+
+	///Retrieves, but does not remove, the head of the queue
+	peek( string )( undefined ),
+	
+	///Removes and returns the head of the queue
+	poll( string )( undefined ),
+
+	///Returns the size of an existing queue, null otherwise
+	size( string )( int )
+}
+
+service QueueUtils {
+    inputPort ip {
+        location:"local"
+        interfaces: QueueUtilsInterface
+    }
+
+    foreign java {
+        class: "joliex.util.QueueUtils"
+    }
+}

--- a/packages/reflection.ol
+++ b/packages/reflection.ol
@@ -1,0 +1,105 @@
+/*
+ *   Copyright (C) 2009 by Fabrizio Montesi <famontesi@gmail.com>         
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+from types.Binding import *
+
+type InvokeRequest:void {
+	.operation:string 
+	.outputPort:string
+	.resourcePath?:string
+	.data?:undefined
+}
+
+type InvocationFaultType:void {
+	.name:string
+	.data:undefined
+}
+
+/*
+type Range:void { .min:int .max:int } // Both extremes are included
+
+type NativeType
+	: string("void")
+	| string("int")
+	| string("string")
+	| string("double")
+	| string("long")
+	| string("raw")
+
+type Type:void {
+	.name:string
+	.nativeType:NativeType
+	.range:Range
+	.subTypes*:Type
+}
+
+type OneWayOperation:void {
+	.name:string
+	.requestType:Type
+}
+
+type FaultType:void {
+	.name:string
+	.type:Type
+}
+
+type RequestResponseOperation:void {
+	.name:string
+	.requestType:Type
+	.responseType:Type
+	.faultType*:FaultType
+}
+
+type Operation:OneWayOperation | RequestResponseOperation
+
+type Interface:void {
+	.name:string
+	.operation*:Operation
+}
+*/
+
+type ReflectionSetOutputPortRequest:void {
+	.name:string
+	.binding:Binding
+}
+
+/**!
+WARNING: the API of this service is experimental. Use it at your own risk.
+*/
+interface ReflectionIface {
+RequestResponse:
+	/**!
+	Invokes the specified .operation at .outputPort.
+	If the operation is a OneWay, the invocation returns no value.
+	*/
+	invoke(InvokeRequest)(undefined) throws OperationNotFound(string) InvocationFault(InvocationFaultType)
+}
+
+service Reflection {
+    inputPort ip {
+        location:"local"
+        interfaces: ReflectionIface
+    }
+
+    foreign java {
+        class: "joliex.lang.reflection.Reflection"
+    }
+}

--- a/packages/runtime.ol
+++ b/packages/runtime.ol
@@ -20,8 +20,7 @@
  *   For details about the authors of this software, see the AUTHORS file. 
  */
 
-from .types.JavaException import *
-from .types.IOException import *
+from .types.IOException import IOExceptionType
 from .types.Binding import *
 
 type LoadEmbeddedServiceRequest:void {

--- a/packages/runtime.ol
+++ b/packages/runtime.ol
@@ -1,0 +1,206 @@
+/*
+ *   Copyright (C) 2008-2019 by Fabrizio Montesi <famontesi@gmail.com>     
+ *   Copyright (C) 2013      by Claudio Guidi    <guidiclaudio@gmail.com>  
+ *                                                                         
+ *   This program is free software; you can redistribute it and/or modify  
+ *   it under the terms of the GNU Library General Public License as       
+ *   published by the Free Software Foundation; either version 2 of the    
+ *   License, or (at your option) any later version.                       
+ *                                                                         
+ *   This program is distributed in the hope that it will be useful,       
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         
+ *   GNU General Public License for more details.                          
+ *                                                                         
+ *   You should have received a copy of the GNU Library General Public     
+ *   License along with this program; if not, write to the                 
+ *   Free Software Foundation, Inc.,                                       
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             
+ *                                                                         
+ *   For details about the authors of this software, see the AUTHORS file. 
+ */
+
+from .types.JavaException import *
+from .types.IOException import *
+from .types.Binding import *
+
+type LoadEmbeddedServiceRequest:void {
+	.filepath:string //< The path to the service to load
+	.type:string //< The type of the service, e.g., Jolie, Java, or JavaScript
+}
+
+type LoadEmbeddedServiceNodeRequest:void {
+	.module:string //< The module target of the service node
+	.serviceNode:string //< Service name to load
+	.argumentValue?: any { ? } //< passing argument
+}
+
+type GetRedirectionRequest:void {
+	.inputPortName:string //< The target input port
+	.resourceName:string //< The resource name of the redirection to get
+}
+
+type SetRedirectionRequest:void {
+	.inputPortName:string //< The target input port
+	.resourceName:string //< The target resource name
+	.outputPortName:string //< The target output port
+}
+
+type RuntimeExceptionType:JavaExceptionType
+
+type SetOutputPortRequest:void {
+	.name:string //< The name of the output port
+	.location:any //< The location of the output port
+	/// The protocol configuration of the output port
+	.protocol?:string //< The name of the protocol (e.g., sodep, http)
+		{ ? }
+}
+
+type SendMessageRequest:void {
+	.operation:string //< The operation the message is for
+	.binding:Binding //< The binding information (location, protocol) to reach the target service
+	.message:undefined //< The message content (payload)
+}
+
+type GetIncludePathResponse:void {
+	.path*:string //< The include paths of the interpreter
+}
+
+type SetMonitorRequest:void {
+	.location:any //< The location of the monitor
+	/// The protocol configuration for the monitor
+	.protocol?:string { ? }
+}
+
+type GetOutputPortRequest: void {
+	.name: string //< The name of the output port
+}
+
+type GetOutputPortResponse: void {
+	.name: string //< The name of the output port
+	.protocol: string //< The protocol name of the output port
+	.location: string //< The location of the output port
+}
+
+type GetOutputPortsResponse: void {
+	/// The output ports used by this interpreter
+	.port*: void {
+	  .name: string //< The name of the output port
+	  .protocol: string //< The protocol name of the output port
+	  .location: string //< The location of the output port
+	}
+}
+
+type HaltRequest: void {
+	.status?: int //< The status code to return to the execution environment
+}
+
+/// Information on the interpreter execution so far
+type Stats:void {
+	/// Information on file descriptors
+	.files:void {
+		.openCount?:long //< Number of open files
+		.maxCount?:long //< Maximum number of open files allowed for this VM
+	}
+	/// OS-related information
+	.os:void {
+		.arch:string //< Architecture
+		.availableProcessors:int //< Number of available processors
+		.name:string //< Name of the OS
+		.systemLoadAverage:double //< System load average
+		.version:string //< OS version
+	}
+}
+
+type MaybeString:void | string
+
+interface RuntimeInterface {
+RequestResponse:
+	/// Get the local in-memory location of this service.
+	getLocalLocation(void)(any),
+
+	/// Set the monitor for this service.
+	setMonitor(SetMonitorRequest)(void),
+
+	/// Load an embedded service.
+	loadEmbeddedService(LoadEmbeddedServiceRequest)(any) throws RuntimeException(RuntimeExceptionType),
+
+	/// Load an embedded service node.
+	loadEmbeddedServiceNode(LoadEmbeddedServiceNodeRequest)(any) throws RuntimeException(RuntimeExceptionType),
+
+	/// Get the output port name that a redirection points to.
+	getRedirection(GetRedirectionRequest)(MaybeString),
+
+	/** Set a redirection at an input port.
+	 * If the redirection with this name does not exist already,
+	 * this operation creates it.
+	 * Otherwise, the redirection is replaced with this one.
+	 */
+	setRedirection(SetRedirectionRequest)(void) throws RuntimeException(RuntimeExceptionType),
+
+	/// Remove a redirection at an input port
+	removeRedirection(GetRedirectionRequest)(void) throws RuntimeException(RuntimeExceptionType),
+
+	/// Get the include paths used by this interpreter
+	getIncludePaths(void)(GetIncludePathResponse),
+
+	/** Set an output port.
+	 * If an output port with this name does not exist already,
+	 * this operation creates it.
+	 * Otherwise, the output port is replaced with this one.
+	 */
+	setOutputPort(SetOutputPortRequest)(void),
+
+	/** Returns the definition of output port definition.
+	 * @throws OutputPortDoesNotExist if the requested output port does not exist.
+	 */
+	getOutputPort( GetOutputPortRequest )( GetOutputPortResponse )
+	  throws OutputPortDoesNotExist,
+
+	/// Returns all the output ports used by this service.
+	getOutputPorts( void )( GetOutputPortsResponse ),
+
+	/// Returns the internal identifier of the executing Jolie process.
+	getProcessId( void )( string ),
+
+	/// Halts non-gracefully the execution of this service.
+	halt(HaltRequest)(void),
+
+	/// Removes the output port with the requested name.
+	removeOutputPort(string)(void),
+
+	/** Stops gracefully the execution of this service.
+	 * Calling this operation is equivalent to invoking the exit statement.
+	 */
+	callExit(any)(void),
+
+	/** Returns a pretty-printed string representation of
+	 * the local state of the invoking Jolie process and
+	 * the global state of this service.
+	 */
+	dumpState(void)(string),
+
+	/// Dynamically loads an external (jar) library.
+	loadLibrary(string)(void) throws IOException(IOExceptionType),
+
+	/// Returns information on the runtime state of the VM.
+	stats(void)(Stats),
+
+	/// Returns the value of an environment variable.
+	getenv(string)(MaybeString),
+
+	/// Returns the version of the Jolie interpreter running this service.
+	getVersion(void)(string)
+
+}
+
+service Runtime {
+    inputPort ip {
+        location:"local"
+        interfaces: RuntimeInterface
+    }
+
+    foreign java {
+        class: "joliex.lang.RuntimeService"
+    }
+}

--- a/packages/scheduler.ol
+++ b/packages/scheduler.ol
@@ -1,0 +1,67 @@
+/*
+ *   Copyright (C) 2008 by Fabrizio Montesi <famontesi@gmail.com>         
+ *                 2018 by Claudio Guidi <cguidi@italianasoftware.com>    
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+type DeleteCronJobRequest: void {
+  .jobName: string
+  .groupName: string
+}
+
+type SetCallBackOperationRequest: void {
+  .operationName: string
+}
+
+type SetCronJobRequest: void {
+  .jobName: string
+  .groupName: string
+  .cronSpecs: void {
+      /* see here for creating correct specs:
+         http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/tutorial-lesson-06.html
+         or http://www.cronmaker.com/
+      */
+         .second: string   		/* 0-59 */
+         .minute: string				/* 0-59 */
+         .hour: string					/* 0-23 */
+         .dayOfMonth: string		/* 1-31 */
+         .month: string				/* 0-11 */
+         .dayOfWeek: string		/* 1-7 (1=Sunday) */
+         .year?: string
+  }
+}
+
+interface SchedulerInterface{
+  RequestResponse:
+    deleteCronJob( DeleteCronJobRequest )( void ),
+    setCronJob( SetCronJobRequest )( void ) throws JobAlreadyExists( void )
+  OneWay:
+    setCallbackOperation( SetCallBackOperationRequest )
+}
+
+service Scheduler {
+    inputPort ip {
+        location:"local"
+        interfaces: SchedulerInterface
+    }
+
+    foreign java {
+        class: "joliex.scheduler.SchedulerService"
+    }
+}

--- a/packages/security_utils.ol
+++ b/packages/security_utils.ol
@@ -1,0 +1,42 @@
+/*
+ *   Copyright (C) 2009 by Fabrizio Montesi <famontesi@gmail.com>         
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+
+type SecureRandomRequest:void {
+	.size:int
+}
+
+interface SecurityUtilsInterface {
+RequestResponse:
+	secureRandom(SecureRandomRequest)(raw),
+	createSecureToken(void)(string)
+}
+
+service SecurityUtils {
+    inputPort ip {
+        location:"local"
+        interfaces: SecurityUtilsInterface
+    }
+
+    foreign java {
+        class: "joliex.security.SecurityUtils"
+    }
+}

--- a/packages/semaphore_utils.ol
+++ b/packages/semaphore_utils.ol
@@ -1,0 +1,58 @@
+/*
+ *   Copyright (C) 2013 by Saverio Giallorenzo <saverio.giallorenzo@gmail.com>
+ *                                                                         
+ *   This program is free software; you can redistribute it and/or modify  
+ *   it under the terms of the GNU Library General Public License as       
+ *   published by the Free Software Foundation; either version 2 of the    
+ *   License, or (at your option) any later version.                       
+ *                                                                         
+ *   This program is distributed in the hope that it will be useful,       
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         
+ *   GNU General Public License for more details.                          
+ *                                                                         
+ *   You should have received a copy of the GNU Library General Public     
+ *   License along with this program; if not, write to the                 
+ *   Free Software Foundation, Inc.,                                       
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             
+ *                                                                         
+ *   For details about the authors of this software, see the AUTHORS file. 
+ */
+
+type SemaphoreRequest: void {
+	.name: string
+	/// the optional number of permits to release/acquire
+	.permits?: int
+}
+
+interface SemaphoreUtilsInterface {
+	RequestResponse:
+	
+	/**!
+	* Releases permits to a semaphore.
+	* If there exists no semaphore with the given ".name", "release" creates a
+	* new semaphore with that name and as many permits as indicated in ".permits".
+	* The default behaviour when value ".permits" is absent is to release one permit.
+	*/
+	release( SemaphoreRequest )( bool ),
+	
+	/**!
+	 * Acquires permits from a semaphore.
+	 * If there exists no semaphore with the given ".name", "acquire" creates a 
+	 * new semaphore with 0 permits with that name.
+	 * The operation returns a response when a new permit is released (see operation "release").
+	 * The default behaviour when value ".permits" is absent is to acquire one permit.
+	 */
+	acquire( SemaphoreRequest )( bool )
+}
+
+service SemaphoreUtils {
+    inputPort ip {
+        location:"local"
+        interfaces: SemaphoreUtilsInterface
+    }
+
+    foreign java {
+        class: "joliex.util.SemaphoreUtils"
+    }
+}

--- a/packages/smtp.ol
+++ b/packages/smtp.ol
@@ -1,0 +1,72 @@
+/*
+ *   Copyright (C) 2008 by Fabrizio Montesi <famontesi@gmail.com>          
+ *                                                                         
+ *   This program is free software; you can redistribute it and/or modify  
+ *   it under the terms of the GNU Library General Public License as       
+ *   published by the Free Software Foundation; either version 2 of the    
+ *   License, or (at your option) any later version.                       
+ *                                                                         
+ *   This program is distributed in the hope that it will be useful,       
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         
+ *   GNU General Public License for more details.                          
+ *                                                                         
+ *   You should have received a copy of the GNU Library General Public     
+ *   License along with this program; if not, write to the                 
+ *   Free Software Foundation, Inc.,                                       
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             
+ *                                                                         
+ *  For details about the authors of this software, see the AUTHORS file.
+ */
+
+from types.JavaException import *
+
+type SendMailRequest:void {
+	/* Host & Authentication */
+	.host:string
+	.authenticate?:void {
+		.username:string
+		.password:string
+	}
+
+	.from:string
+	.replyTo[0,*]:string
+
+	/* Recipients */
+	.to[1,*]:string
+	.cc[0,*]:string
+	.bcc[0,*]:string
+
+	/* Subject */
+	.subject:string
+
+	/* Content */
+	.content:string
+
+	/* Content type
+	 * can be "text/plain", "text/html", ..  [MIME tags]
+	 * defaults to "text/plain"
+	 */
+	.contentType?:string
+	.attachment*:void{
+		.content:raw
+		.filename:string
+		.contentType:string
+	}
+}
+
+interface SMTPInterface {
+RequestResponse:
+	sendMail(SendMailRequest)(void) throws SMTPFault(undefined)
+}
+
+service SMTP {
+    inputPort ip {
+        location:"local"
+        interfaces: SMTPInterface
+    }
+
+    foreign java {
+        class: "joliex.mail.SMTPService"
+    }
+}

--- a/packages/string_utils.ol
+++ b/packages/string_utils.ol
@@ -1,0 +1,138 @@
+/*
+ *   Copyright (C) 2008 by Fabrizio Montesi <famontesi@gmail.com>         
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+type EndsWithRequest: string {
+	.suffix: string
+}
+
+type ReplaceRequest:string {
+	.regex:string
+	.replacement:string
+}
+
+type JoinRequest:void {
+	.piece[0,*]:string
+	.delimiter:string
+}
+
+type SplitByLengthRequest:string {
+	.length:int
+}
+
+type SplitResult:void {
+	.result[0,*]:string
+}
+
+type SplitRequest:string {
+	.limit?:int
+	.regex:string
+}
+
+type PadRequest:string {
+	.length:int
+	.char:string
+}
+
+type MatchRequest:string {
+	.regex:string
+}
+
+type MatchResult:int { // 1 if at least a match was found, 0 otherwise.
+	.group[0,*]:string
+}
+
+type StartsWithRequest:string {
+	.prefix:string
+}
+
+type SubStringRequest:string {
+	.begin:int
+	.end?:int
+}
+
+type StringItemList:void {
+	.item*:string
+}
+
+type IndexOfRequest: string {
+	.word: string
+}
+
+type IndexOfResponse: int
+
+type ContainsRequest:string {
+	.substring:string
+}
+
+/**!
+ * An interface for supporting string manipulation operations.
+ */
+interface StringUtilsInterface {
+RequestResponse:
+	/**!
+	  checks if a string ends with a given suffix
+	*/
+	endsWith( EndsWithRequest )( bool ),
+
+	/**!
+	* it returns a random UUID
+	*/
+	getRandomUUID( void )( string ),
+
+	/**!
+	 * Returns true if the string contains .substring
+	 */
+	contains( ContainsRequest )( bool ),
+	indexOf(IndexOfRequest)(IndexOfResponse),
+	substring(SubStringRequest)(string),
+	join(JoinRequest)(string),
+	leftPad(PadRequest)(string),
+	rightPad(PadRequest)(string),
+	length(string)(int),
+	match(MatchRequest)(MatchResult),
+	find(MatchRequest)(MatchResult),
+	replaceAll(ReplaceRequest)(string),
+	replaceFirst(ReplaceRequest)(string),
+	sort(StringItemList)(StringItemList),
+	split(SplitRequest)(SplitResult),
+	splitByLength(SplitByLengthRequest)(SplitResult),
+	trim(string)(string),
+	toLowerCase(string)(string),
+	toUpperCase(string)(string),
+
+	/**!
+	* checks if the passed string starts with a given prefix
+	*/
+	startsWith(StartsWithRequest)( bool ),
+	valueToPrettyString(undefined)(string)
+}
+
+
+service StringUtils {
+    inputPort ip {
+        location:"local"
+        interfaces: StringUtilsInterface
+    }
+
+    foreign java {
+        class: "joliex.util.StringUtils"
+    }
+}

--- a/packages/time.ol
+++ b/packages/time.ol
@@ -1,0 +1,180 @@
+/*
+ *   Copyright (C) 2008 by Fabrizio Montesi <famontesi@gmail.com>          
+ *                                                                         
+ *   This program is free software; you can redistribute it and/or modify  
+ *   it under the terms of the GNU Library General Public License as       
+ *   published by the Free Software Foundation; either version 2 of the    
+ *   License, or (at your option) any later version.                       
+ *                                                                         
+ *   This program is distributed in the hope that it will be useful,       
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         
+ *   GNU General Public License for more details.                          
+ *                                                                         
+ *   You should have received a copy of the GNU Library General Public     
+ *   License along with this program; if not, write to the                 
+ *   Free Software Foundation, Inc.,                                       
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             
+ *                                                                         
+ *   For details about the authors of this software, see the AUTHORS file. 
+ */
+
+
+/**
+*WARNING: work in progress, the API is unstable.
+*/
+
+
+type DateValuesType:void {
+	.day:int
+	.month:int
+	.year:int
+}
+
+type TimeValuesType:void {
+	.hour:int
+	.minute:int
+	.second:int
+}
+
+type DateValuesRequestType:string {
+	/*
+	* Date format.
+	* If not specified, it defaults to "dd/MM/yyyy"
+	*/
+
+	.format?:string
+}
+
+type CurrentDateTimeRequestType:void {
+	/*
+	* 	Date format.
+	* 	If not specified, it defaults to "dd/MM/yyyy"
+	*/
+
+	.format?:string
+}
+
+type DiffDateRequestType:void {
+	.format?:string
+	.date1:string
+	.date2:string
+}
+type GetTimeDiffRequest:void {
+	.time1:string
+	.time2:string
+}
+
+type GetTimestampFromStringRequest:string {
+	.format?:string
+	.language?: string
+}
+
+type GetDateTimeRequest: long {
+  .format?: string
+
+}
+
+type GetDateTimeResponse: string {
+	.day:int
+	.month:int
+	.year:int
+	.hour:int
+	.minute:int
+	.second:int
+}
+
+type DateTimeType:void{
+	.day:int
+	.month:int
+	.year:int
+	.hour:int
+	.minute:int
+	.second:int
+}
+
+
+type SetNextTimeOutRequest: int {
+	.operation?: string
+	.message?: undefined
+}
+
+type ScheduleTimeOutRequest: int {
+	.operation?: string
+	/*
+	* If the value is not set, it will default to "timeout"
+	*
+	*/
+	.message?: undefined
+	/*
+	*	Possible values are DAYS, HOURS, MICROSECONDS, MILLISECONDS, MINUTES, NANOSECONDS, SECONDS.
+	*   If the value is not set or recognized, it will default to MILLISECONDS
+	*/
+	.timeunit?: string
+}
+
+interface TimeInterface{
+	OneWay:
+		/**!
+		  it sets a timeout whose duration is in milliseconds and it is represented by the root value of the message
+		  When the alarm is triggered a message whose content is defined in .message is sent to operation defined in .operation
+		  ( default: timeout )
+		*/
+		setNextTimeout(SetNextTimeOutRequest),
+		setNextTimeoutByDateTime, setNextTimeoutByTime,
+		/**! It stops the current timeout previously set with a setNextTimeout */
+		stopNextTimeout( void )
+	RequestResponse:
+			/**!
+		* Cancels a timeout from a long-value created from #scheduleTimeout
+		*/
+		cancelTimeout(long)(bool),
+
+		getCurrentDateTime(CurrentDateTimeRequestType)(string), 
+		
+		sleep,
+
+		/**!
+		* It returns a date time in a string format starting from a timestamp
+		*/
+		getDateTime( GetDateTimeRequest )( GetDateTimeResponse ),
+
+		/**!
+		* Converts an input string into a date expressed by means of
+		* three elements: day, month and year. The request may specify the
+		* date parsing format. See #DateValuesRequestType for details.
+		*/
+		getDateValues(DateValuesRequestType)(DateValuesType) throws InvalidDate,
+
+		/**!
+		* Returns the current date split in three fields: day, month and year
+		*/
+		getCurrentDateValues(void)(DateValuesType),
+		getDateDiff(DiffDateRequestType)(int),
+
+		/**!
+		* Warning: this is temporary and subject to future change as soon as long is supported by Jolie.
+		*/
+		getCurrentTimeMillis(void)(long),
+		getTimeValues(string)(TimeValuesType),
+		getTimeDiff(GetTimeDiffRequest)(int),
+		getTimeFromMilliSeconds(int)(TimeValuesType),
+		getTimestampFromString(GetTimestampFromStringRequest)(long) throws InvalidTimestamp,
+		getDateTimeValues(GetTimestampFromStringRequest)(DateTimeType) throws InvalidDate,
+		/**!
+		* Schedules a timeout, which can be cancelled using #cancelTimeout from the returned string. Default .timeunit value is MILLISECONDS, .operation default is "timeout".
+		*/
+		scheduleTimeout(ScheduleTimeOutRequest)(long) throws InvalidTimeUnit
+
+}
+
+service Time {
+    inputPort ip {
+        location:"local"
+        interfaces: TimeInterface
+    }
+
+    foreign java {
+        class: "joliex.util.TimeService"
+    }
+}

--- a/packages/types/Binding.ol
+++ b/packages/types/Binding.ol
@@ -1,0 +1,25 @@
+/*
+ *   Copyright (C) 2009 by Fabrizio Montesi <famontesi@gmail.com>         
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+type Binding:void {
+	.location:string
+	.protocol?:string { ? }
+}

--- a/packages/types/IOException.ol
+++ b/packages/types/IOException.ol
@@ -1,0 +1,24 @@
+/*
+ *   Copyright (C) 2009 by Fabrizio Montesi <famontesi@gmail.com>         
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+from .JavaException import JavaExceptionType
+
+type IOExceptionType:JavaExceptionType

--- a/packages/types/JavaException.ol
+++ b/packages/types/JavaException.ol
@@ -1,0 +1,28 @@
+/*
+ *   Copyright (C) 2009-2012 by Fabrizio Montesi <famontesi@gmail.com>    
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+type JavaExceptionType:string { // Exception message
+	.stackTrace:string // The stack trace of the exception
+}
+
+type WeakJavaExceptionType:any { // Exception message
+	.stackTrace?:string // The stack trace of the exception
+}

--- a/packages/types/definition_types.ol
+++ b/packages/types/definition_types.ol
@@ -1,0 +1,114 @@
+/*
+ *   Copyright (C) 2009 Claudio Guidi <cguidi@italianasoftware.com>
+ *                                                                        
+ *   This program is free software; you can redistribute it and/or modify 
+ *   it under the terms of the GNU Library General Public License as      
+ *   published by the Free Software Foundation; either version 2 of the   
+ *   License, or (at your option) any later version.                      
+ *                                                                        
+ *   This program is distributed in the hope that it will be useful,      
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of       
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        
+ *   GNU General Public License for more details.                         
+ *                                                                        
+ *   You should have received a copy of the GNU Library General Public    
+ *   License along with this program; if not, write to the                
+ *   Free Software Foundation, Inc.,                                      
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.            
+ *                                                                        
+ *   For details about the authors of this software, see the AUTHORS file.
+ */
+
+type NativeType: void {
+  .string_type: bool
+} | void {
+  .int_type: bool
+} | void {
+  .double_type: bool
+} | void {
+  .any_type: bool
+} | void {
+  .void_type: bool
+} | void {
+  .raw_type: bool
+} | void {
+  .bool_type: bool
+} | void {
+  .long_type: bool
+} 
+
+
+type Cardinality: void {
+  .min: int
+  .max?: int
+  .infinite?: int
+}
+
+type SubType: void {
+  .name: string
+  .cardinality: Cardinality
+  .type: Type
+  .documentation?: string
+}
+
+type TypeInLine: void {
+  .root_type: NativeType
+  .sub_type*: SubType
+}
+
+type TypeLink: void {
+  .link_name: string
+}
+
+type TypeChoice: void {
+  .choice: void {
+      .left_type: TypeInLine | TypeLink 
+      .right_type: Type
+  }
+}
+
+type TypeUndefined: void {
+  .undefined: bool
+}
+
+type Type: TypeInLine | TypeLink | TypeChoice | TypeUndefined 
+
+type TypeDefinition: void {
+  .name: string
+  .type: Type
+  .documentation?: string
+}
+
+
+type Fault: void {
+  .name: string
+  .type: NativeType | TypeUndefined | TypeLink
+}
+
+type Operation: void {
+  .operation_name: string
+  .documentation?: string
+  .input: string
+  .output?: string
+  .fault*: Fault
+}
+
+type Interface: void {
+  .name: string
+  .types*: TypeDefinition
+  .operations*: Operation
+  .documentation?: string
+}
+
+type Port: void {
+  .name: string
+  .protocol: string
+  .location: any
+  .interfaces*: Interface
+}
+
+type Service: void {
+  .name: string
+  .input*: string
+  .output*: string
+}

--- a/packages/uri_templates.ol
+++ b/packages/uri_templates.ol
@@ -1,0 +1,52 @@
+/*
+ *   Copyright (C) 2008 by Fabrizio Montesi <famontesi@gmail.com>          
+ *                                                                         
+ *   This program is free software; you can redistribute it and/or modify  
+ *   it under the terms of the GNU Library General Public License as       
+ *   published by the Free Software Foundation; either version 2 of the    
+ *   License, or (at your option) any later version.                       
+ *                                                                         
+ *   This program is distributed in the hope that it will be useful,       
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         
+ *   GNU General Public License for more details.                          
+ *                                                                         
+ *   You should have received a copy of the GNU Library General Public     
+ *   License along with this program; if not, write to the                 
+ *   Free Software Foundation, Inc.,                                       
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             
+ *                                                                         
+ *   For details about the authors of this software, see the AUTHORS file. 
+ */
+
+type UriMatchRequest:void {
+	.uri:string
+	.template:string
+}
+
+type MatchResponse:bool { ? }
+
+type ExpandRequest:void {
+	.template:string
+	.params?:undefined
+}
+
+/**!
+WARNING: the API of this service is experimental. Use it at your own risk.
+*/
+interface UriTemplatesIface {
+RequestResponse:
+	match(UriMatchRequest)(MatchResponse),
+	expand(ExpandRequest)(string)
+}
+
+service UriTemplates {
+    inputPort ip {
+        location:"local"
+        interfaces: UriTemplatesIface
+    }
+
+    foreign java {
+        class: "joliex.util.UriTemplates"
+    }
+}

--- a/packages/web_services_utils.ol
+++ b/packages/web_services_utils.ol
@@ -1,0 +1,38 @@
+/*
+ *   Copyright (C) 2010 by Fabrizio Montesi <famontesi@gmail.com>          
+ *                                                                         
+ *   This program is free software; you can redistribute it and/or modify  
+ *   it under the terms of the GNU Library General Public License as       
+ *   published by the Free Software Foundation; either version 2 of the    
+ *   License, or (at your option) any later version.                       
+ *                                                                         
+ *   This program is distributed in the hope that it will be useful,       
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         
+ *   GNU General Public License for more details.                          
+ *                                                                         
+ *   You should have received a copy of the GNU Library General Public     
+ *   License along with this program; if not, write to the                 
+ *   Free Software Foundation, Inc.,                                       
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             
+ *                                                                         
+ *   For details about the authors of this software, see the AUTHORS file. 
+ */
+
+from types.IOException import *
+
+interface WebServicesUtilsInterface {
+RequestResponse:
+	wsdlToJolie(string)(string) throws IOException(IOExceptionType)
+}
+
+service WebServicesUtils {
+    inputPort ip {
+        location:"local"
+        interfaces: WebServicesUtilsInterface
+    }
+
+    foreign java {
+        class: "joliex.util.WebServicesUtils"
+    }
+}

--- a/packages/xml_utils.ol
+++ b/packages/xml_utils.ol
@@ -1,0 +1,88 @@
+/*
+ *   Copyright (C) 2009 by Fabrizio Montesi <famontesi@gmail.com>          
+ *                                                                         
+ *   This program is free software; you can redistribute it and/or modify  
+ *   it under the terms of the GNU Library General Public License as       
+ *   published by the Free Software Foundation; either version 2 of the    
+ *   License, or (at your option) any later version.                       
+ *                                                                         
+ *   This program is distributed in the hope that it will be useful,       
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         
+ *   GNU General Public License for more details.                          
+ *                                                                         
+ *   You should have received a copy of the GNU Library General Public     
+ *   License along with this program; if not, write to the                 
+ *   Free Software Foundation, Inc.,                                       
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             
+ *                                                                         
+ *   For details about the authors of this software, see the AUTHORS file. 
+ */
+
+from types.JavaException import *
+from types.IOException import *
+
+// TODO: fault typing in the Java code
+
+type XMLTransformationRequest:void {
+	.source:string
+	.xslt:string
+}
+
+type XMLToValueRequest:any {
+	.isXmlStore?: bool 						// if true, set xml_store format, xml otherwise. Default: true if no options are specified, false otherwise
+	.options?:void {							// if no options are specified, the xml_store format will be used for processing the document
+		.includeAttributes?:bool 		// Default: false
+		.includeRoot?: bool 				// Default: false, include root into the conversion
+		.schemaUrl?:string 					// Default: none
+		.schemaLanguage?:string 		// Default: "http://www.w3.org/2001/XMLSchema" (see class "SchemaFactory")
+		.charset?:string 						// set the encoding. Default: system (eg. for Unix-like OS UTF-8) or header specification
+		.skipMixedText?: bool 	// skip the mixed elements, default false
+	}
+}
+
+type ValueToXmlRequest: void {
+	.root: any { ? }					// the value to be converted
+	.rootNodeName?: string    // if not specified, there must be only one root node
+	.isXmlStore?: bool				// if true xml_store format will be used, xml otherwise. Default: true
+	.plain?:bool 							// DEPRECATED: Default: false (= storage XML)
+	.omitXmlDeclaration?:bool // Default: false (with XML declaration)
+	.indent?:bool 						// Default: false
+	.applySchema?: void {
+			.schema: string					// set the schema to use, skipped if isXmlStore = true
+			.doctypeSystem?: string
+			.encoding?: string
+	}
+}
+
+interface XmlUtilsInterface{
+	RequestResponse:
+		transform( XMLTransformationRequest )(string)
+				throws TransformerException( JavaExceptionType ),
+		/**!
+		 * Transforms the value contained within the root node into an xml string.
+		 *
+		 * The base value of ValueToXmlRequest.root will be discarded, the rest gets converted recursively
+		 */
+		valueToXml( ValueToXmlRequest )(string)
+				throws IOException( IOExceptionType )
+				       IllegalArgumentException( string ),
+		/**!
+		 * Transforms the base value in XML format (data types string, raw) into a Jolie value
+		 *
+		 * The XML root node will be discarded, the rest gets converted recursively
+		 */
+		xmlToValue( XMLToValueRequest )( undefined )
+				throws IOException( IOExceptionType )
+}
+
+service XmlUtils {
+    inputPort ip {
+        location:"local"
+        interfaces: XmlUtilsInterface
+    }
+
+    foreign java {
+        class: "joliex.util.XmlUtils"
+    }
+}

--- a/packages/xml_utils.ol
+++ b/packages/xml_utils.ol
@@ -19,8 +19,8 @@
  *   For details about the authors of this software, see the AUTHORS file. 
  */
 
-from types.JavaException import *
-from types.IOException import *
+from types.JavaException import JavaExceptionType
+from types.IOException import IOExceptionType
 
 // TODO: fault typing in the Java code
 

--- a/packages/xmpp.ol
+++ b/packages/xmpp.ol
@@ -1,0 +1,50 @@
+/*
+ *   Copyright (C) 2009 by Fabrizio Montesi <famontesi@gmail.com>          
+ *                                                                         
+ *   This program is free software; you can redistribute it and/or modify  
+ *   it under the terms of the GNU Library General Public License as       
+ *   published by the Free Software Foundation; either version 2 of the    
+ *   License, or (at your option) any later version.                       
+ *                                                                         
+ *   This program is distributed in the hope that it will be useful,       
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         
+ *   GNU General Public License for more details.                          
+ *                                                                         
+ *   You should have received a copy of the GNU Library General Public     
+ *   License along with this program; if not, write to the                 
+ *   Free Software Foundation, Inc.,                                       
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             
+ *                                                                         
+ *   For details about the authors of this software, see the AUTHORS file. 
+ */
+
+type ConnectionRequest:void {
+	.serviceName:string
+	.host?:string
+	.port?:int
+	.username:string
+	.password:string
+	.resource?:string
+}
+
+type SendMessageRequest:string {
+	.to:string
+}
+
+interface XMPPInterface {
+RequestResponse:
+	connect(ConnectionRequest)(void) throws XMPPException,
+	sendMessage(SendMessageRequest)(void) throws XMPPException
+}
+
+service XMPP {
+    inputPort ip {
+        location:"local"
+        interfaces: XMPPInterface
+    }
+
+    foreign java {
+        class: "joliex.xmpp.XMPPService"
+    }
+}

--- a/packages/zip_utils.ol
+++ b/packages/zip_utils.ol
@@ -1,0 +1,66 @@
+/*
+ *   Copyright (C) 2008 by Fabrizio Montesi                                
+ *                                                                         
+ *   This program is free software; you can redistribute it and/or modify  
+ *   it under the terms of the GNU Library General Public License as       
+ *   published by the Free Software Foundation; either version 2 of the    
+ *   License, or (at your option) any later version.                       
+ *                                                                         
+ *   This program is distributed in the hope that it will be useful,       
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         
+ *   GNU General Public License for more details.                          
+ *                                                                         
+ *   You should have received a copy of the GNU Library General Public     
+ *   License along with this program; if not, write to the                 
+ *   Free Software Foundation, Inc.,                                       
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             
+ *                                                                         
+ *   For details about the authors of this software, see the AUTHORS file. 
+ */
+
+from types.IOException import *
+
+type ReadEntryRequest:void {
+	.filename?:string
+	.archive?:raw
+	.entry:string
+}
+
+type ZipRequest:void { ? }
+
+type ListEntriesRequest: void {
+	.filename?:string
+	.archive?:raw
+}
+type ListEntriesResponse: void {
+	.entry*: string
+}
+
+type UnzipRequest: void {
+	.filename: string
+	.targetPath: string
+}
+
+type UnzipResponse: void {
+	.entry*: string
+}
+
+interface ZipUtilsInterface {
+RequestResponse:
+	listEntries(ListEntriesRequest)(ListEntriesResponse) throws IOException(IOExceptionType),
+	readEntry(ReadEntryRequest)(any) throws IOException(IOExceptionType),
+	zip(ZipRequest)(raw) throws IOException(IOExceptionType),
+	unzip( UnzipRequest )( UnzipResponse ) throws FileNotFound, IOException
+}
+
+service ZipUtils {
+    inputPort ip {
+        location:"local"
+        interfaces: ZipUtilsInterface
+    }
+
+    foreign java {
+        class: "joliex.util.ZipUtils"
+    }
+}


### PR DESCRIPTION
- fix bug duplicate symbol when referring to importing external symbol multiple times
- porting the standard library to the service node syntax.