### PR TITLE
Remove embed type check in EmbeddedServiceLoader

### DIFF
--- a/jolie/src/main/java/jolie/Interpreter.java
+++ b/jolie/src/main/java/jolie/Interpreter.java
@@ -221,16 +221,6 @@ public class Interpreter {
 		}
 	}
 
-	// private static class ParameterConfiguration {
-	// private final VariablePath variablePath;
-	// private final Type type;
-
-	// public ParameterConfiguration( VariablePath variablePath, Type type ) {
-	// this.variablePath = variablePath;
-	// this.type = type;
-	// }
-	// }
-
 	private static final Logger LOGGER = Logger.getLogger( Constants.JOLIE_LOGGER_NAME );
 
 	private CommCore commCore;
@@ -265,7 +255,6 @@ public class Interpreter {
 	// private long inputMessageTimeout = 24 * 60 * 60 * 1000; // 1 day
 	private final long persistentConnectionTimeout = 60 * 60 * 1000; // 1 hour
 	private final long awaitTerminationTimeout = 60 * 1000; // 1 minute
-	// private Optional< ParameterConfiguration > parameterConfiguration = Optional.empty();
 
 	private final Map< URI, SymbolTable > symbolTables;
 
@@ -305,10 +294,6 @@ public class Interpreter {
 	public Tracer tracer() {
 		return tracer;
 	}
-
-	// public void setParameterConfiguration( VariablePath variablePath, Type type ) {
-	// parameterConfiguration = Optional.of( new ParameterConfiguration( variablePath, type ) );
-	// }
 
 	public void fireMonitorEvent( MonitoringEvent event ) {
 		if( monitor != null ) {

--- a/jolie/src/main/java/jolie/OOITBuilder.java
+++ b/jolie/src/main/java/jolie/OOITBuilder.java
@@ -1601,16 +1601,10 @@ public class OOITBuilder implements OLVisitor {
 					: interpreter.getOutputPort( n.bindingPort().id() ).locationVariablePath();
 
 			Expression passingArgument = buildExpression( n.passingParameter() );
-			Type acceptingParameterType = Type.UNDEFINED;
-
-			if( n.service().parameterConfiguration().isPresent() ) {
-				acceptingParameterType = getOrBuildType( n.service().parameterConfiguration().get().type() );
-			}
 
 			final EmbeddedServiceConfiguration embeddedServiceConfiguration =
 				new EmbeddedServiceLoader.ServiceNodeEmbeddedConfiguration( n.service().type(), n.service(),
-					passingArgument,
-					acceptingParameterType );
+					passingArgument );
 
 			interpreter.addEmbeddedServiceLoader(
 				EmbeddedServiceLoader.create(

--- a/jolie/src/main/java/jolie/runtime/embedding/EmbeddedServiceLoader.java
+++ b/jolie/src/main/java/jolie/runtime/embedding/EmbeddedServiceLoader.java
@@ -19,6 +19,7 @@
 
 package jolie.runtime.embedding;
 
+import java.util.Optional;
 import jolie.Interpreter;
 import jolie.lang.Constants;
 import jolie.lang.parse.ast.Program;
@@ -27,9 +28,6 @@ import jolie.net.CommChannel;
 import jolie.runtime.Value;
 import jolie.runtime.VariablePath;
 import jolie.runtime.expression.Expression;
-import jolie.runtime.typing.Type;
-
-import java.util.Optional;
 
 public abstract class EmbeddedServiceLoader {
 	private final Expression channelDest;
@@ -49,7 +47,7 @@ public abstract class EmbeddedServiceLoader {
 				ServiceNodeEmbeddedConfiguration serviceNodeConfiguration =
 					(ServiceNodeEmbeddedConfiguration) configuration;
 				ret = ServiceNodeLoader.create( channelDest, interpreter, serviceNodeConfiguration.serviceNode,
-					serviceNodeConfiguration.parameter(), serviceNodeConfiguration.acceptingParameterType() );
+					serviceNodeConfiguration.parameter() );
 			} else if( configuration.isInternal() ) {
 				InternalEmbeddedServiceConfiguration internalConfiguration =
 					(InternalEmbeddedServiceConfiguration) configuration;
@@ -221,14 +219,12 @@ public abstract class EmbeddedServiceLoader {
 	public static class ServiceNodeEmbeddedConfiguration extends EmbeddedServiceConfiguration {
 		private final ServiceNode serviceNode;
 		private final Expression parameter;
-		private final Type acceptingParameterType;
 
 		public ServiceNodeEmbeddedConfiguration( Constants.EmbeddedServiceType type, ServiceNode node,
-			Expression parameter, Type acceptingParameterType ) {
+			Expression parameter ) {
 			super( type );
 			this.serviceNode = node;
 			this.parameter = parameter;
-			this.acceptingParameterType = acceptingParameterType;
 		}
 
 		public ServiceNode serviceNode() {
@@ -239,8 +235,5 @@ public abstract class EmbeddedServiceLoader {
 			return this.parameter;
 		}
 
-		public Type acceptingParameterType() {
-			return this.acceptingParameterType;
-		}
 	}
 }

--- a/jolie/src/main/java/jolie/runtime/embedding/JavaServiceNodeLoader.java
+++ b/jolie/src/main/java/jolie/runtime/embedding/JavaServiceNodeLoader.java
@@ -19,6 +19,10 @@
 
 package jolie.runtime.embedding;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URISyntaxException;
+import java.util.Map;
 import jolie.Interpreter;
 import jolie.JolieClassLoader;
 import jolie.lang.parse.ast.OutputPortInfo;
@@ -27,13 +31,7 @@ import jolie.runtime.FaultException;
 import jolie.runtime.JavaService;
 import jolie.runtime.Value;
 import jolie.runtime.expression.Expression;
-import jolie.runtime.typing.Type;
 import jolie.tracer.EmbeddingTraceAction;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.net.URISyntaxException;
-import java.util.Map;
 
 public class JavaServiceNodeLoader extends ServiceNodeLoader {
 
@@ -41,8 +39,8 @@ public class JavaServiceNodeLoader extends ServiceNodeLoader {
 	private final Map< String, OutputPortInfo > outputPortInfos;
 
 	protected JavaServiceNodeLoader( Expression channelDest, Interpreter interpreter, ServiceNodeJava serviceNode,
-		Expression passingParameter, Type acceptingType ) throws EmbeddedServiceCreationException {
-		super( channelDest, interpreter, serviceNode, passingParameter, acceptingType );
+		Expression passingParameter ) throws EmbeddedServiceCreationException {
+		super( channelDest, interpreter, serviceNode, passingParameter );
 		JavaService service = null;
 		Map< String, OutputPortInfo > ops = null;
 		try {

--- a/jolie/src/main/java/jolie/runtime/embedding/JolieServiceNodeLoader.java
+++ b/jolie/src/main/java/jolie/runtime/embedding/JolieServiceNodeLoader.java
@@ -29,13 +29,12 @@ import jolie.lang.parse.ast.ServiceNode;
 import jolie.lang.parse.util.ProgramBuilder;
 import jolie.runtime.Value;
 import jolie.runtime.expression.Expression;
-import jolie.runtime.typing.Type;
 
 public class JolieServiceNodeLoader extends ServiceNodeLoader {
 
 	protected JolieServiceNodeLoader( Expression channelDest, Interpreter currInterpreter, ServiceNode serviceNode,
-		Expression passingParameter, Type acceptingType ) {
-		super( channelDest, currInterpreter, serviceNode, passingParameter, acceptingType );
+		Expression passingParameter ) {
+		super( channelDest, currInterpreter, serviceNode, passingParameter );
 	}
 
 	@Override

--- a/jolie/src/main/java/jolie/runtime/embedding/ServiceNodeLoader.java
+++ b/jolie/src/main/java/jolie/runtime/embedding/ServiceNodeLoader.java
@@ -20,63 +20,45 @@
 package jolie.runtime.embedding;
 
 import java.util.concurrent.atomic.AtomicLong;
-
 import jolie.Interpreter;
 import jolie.lang.Constants.EmbeddedServiceType;
 import jolie.lang.parse.ast.ServiceNode;
 import jolie.lang.parse.ast.ServiceNodeJava;
 import jolie.runtime.Value;
 import jolie.runtime.expression.Expression;
-import jolie.runtime.typing.Type;
-import jolie.runtime.typing.TypeCheckingException;
 
 public abstract class ServiceNodeLoader extends EmbeddedServiceLoader {
 	private final Interpreter currInterpreter;
 	private final ServiceNode serviceNode;
 	private final Expression passingParameter;
-	private final Type acceptingType;
 	protected final static AtomicLong SERVICE_LOADER_COUNTER = new AtomicLong();
 
 	protected ServiceNodeLoader( Expression channelDest, Interpreter currInterpreter,
-		ServiceNode serviceNode, Expression passingParameter, Type acceptingType ) {
+		ServiceNode serviceNode, Expression passingParameter ) {
 		super( channelDest );
 		this.currInterpreter = currInterpreter;
 		this.serviceNode = serviceNode;
 		this.passingParameter = passingParameter;
-		this.acceptingType = acceptingType;
 	}
 
 	public abstract void load( Value v ) throws EmbeddedServiceLoadingException;
 
 	public static ServiceNodeLoader create( Expression channelDest, Interpreter currInterpreter,
-		ServiceNode serviceNode, Expression passingParameter, Type acceptingType )
+		ServiceNode serviceNode, Expression passingParameter )
 		throws EmbeddedServiceCreationException {
 		if( serviceNode.type() == EmbeddedServiceType.SERVICENODE ) {
-			return new JolieServiceNodeLoader( channelDest, currInterpreter, serviceNode, passingParameter,
-				acceptingType );
+			return new JolieServiceNodeLoader( channelDest, currInterpreter, serviceNode, passingParameter );
 		} else if( serviceNode.type() == EmbeddedServiceType.SERVICENODE_JAVA ) {
 			return new JavaServiceNodeLoader( channelDest, currInterpreter, (ServiceNodeJava) serviceNode,
-				passingParameter, acceptingType );
+				passingParameter );
 		}
 		return null;
 	}
 
 	@Override
 	public void load() throws EmbeddedServiceLoadingException {
-		try {
-			Value passingValue = passingParameter == null ? Value.create() : passingParameter.evaluate();
-			// Value pathValue = Value.create();
-
-			if( this.serviceNode.parameterConfiguration().isPresent() ) {
-				this.acceptingType.check( passingValue );
-				// pathValue.getFirstChild( this.serviceNode.parameterConfiguration().get().variablePath() )
-				// .deepCopy( passingValue );
-			}
-
-			load( passingValue );
-		} catch( TypeCheckingException e ) {
-			throw new EmbeddedServiceLoadingException( e );
-		}
+		Value passingValue = passingParameter == null ? Value.create() : passingParameter.evaluate();
+		load( passingValue );
 	}
 
 	public String serviceName() {


### PR DESCRIPTION
As the previous commit has enabled service parameter type checking in the initialization of the interpreter. This PR eliminates the checking point on the embed statement "load" method. Also removes the requirement of the Type object to create a Service loader. So the upcoming feature of embedding service node with Module System in runtime service can create EmbeddedServiceLoader object without bother building an accepting parameter Type object.