### PR TITLE
Fix ExecutionInfo not reset when parsing different services

### DIFF
--- a/libjolie/src/main/java/jolie/lang/parse/OLParser.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParser.java
@@ -954,7 +954,6 @@ public class OLParser extends AbstractParser {
 			throwException( "Expected execution mode, found " + token.content() );
 			break;
 		}
-		programBuilder.addChild( new ExecutionInfo( getContext(), mode ) );
 		nextToken();
 		if( inCurlyBrackets ) {
 			eat( Scanner.TokenType.RCURLY, "} expected" );


### PR DESCRIPTION
Fix #284. The bug caused by _parseExecutionInfo is adding the ExecutionInfo to the parent program builder, which is copied over on the creation of another service. Remove this line fixed the issue :)