### PR TITLE
Add support for stateless visitors of Jolie AST

### DIFF
--- a/jolie/src/main/java/jolie/OOITBuilder.java
+++ b/jolie/src/main/java/jolie/OOITBuilder.java
@@ -25,7 +25,7 @@ import jolie.lang.Constants.OperandType;
 import jolie.lang.parse.CorrelationFunctionInfo;
 import jolie.lang.parse.CorrelationFunctionInfo.CorrelationPairInfo;
 import jolie.lang.parse.OLParser;
-import jolie.lang.parse.OLVisitor;
+import jolie.lang.parse.VoidOLVisitor;
 import jolie.lang.parse.Scanner;
 import jolie.lang.parse.ast.*;
 import jolie.lang.parse.ast.CorrelationSetInfo.CorrelationVariableInfo;
@@ -76,9 +76,9 @@ import java.util.function.BiPredicate;
  * Builds an interpretation tree by visiting a Jolie abstract syntax tree.
  * 
  * @author Fabrizio Montesi
- * @see OLVisitor
+ * @see VoidOLVisitor
  */
-public class OOITBuilder implements OLVisitor {
+public class OOITBuilder implements VoidOLVisitor {
 	private final Program program;
 	private final Value initValue;
 	private boolean valid = true;

--- a/jolie/src/main/java/jolie/OOITBuilder.java
+++ b/jolie/src/main/java/jolie/OOITBuilder.java
@@ -25,7 +25,7 @@ import jolie.lang.Constants.OperandType;
 import jolie.lang.parse.CorrelationFunctionInfo;
 import jolie.lang.parse.CorrelationFunctionInfo.CorrelationPairInfo;
 import jolie.lang.parse.OLParser;
-import jolie.lang.parse.VoidOLVisitor;
+import jolie.lang.parse.UnitOLVisitor;
 import jolie.lang.parse.Scanner;
 import jolie.lang.parse.ast.*;
 import jolie.lang.parse.ast.CorrelationSetInfo.CorrelationVariableInfo;
@@ -76,9 +76,9 @@ import java.util.function.BiPredicate;
  * Builds an interpretation tree by visiting a Jolie abstract syntax tree.
  * 
  * @author Fabrizio Montesi
- * @see VoidOLVisitor
+ * @see UnitOLVisitor
  */
-public class OOITBuilder implements VoidOLVisitor {
+public class OOITBuilder implements UnitOLVisitor {
 	private final Program program;
 	private final Value initValue;
 	private boolean valid = true;

--- a/libjolie/src/main/java/jolie/lang/parse/OLParseTreeOptimizer.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParseTreeOptimizer.java
@@ -124,7 +124,7 @@ public class OLParseTreeOptimizer {
 	 * TODO Optimize expressions and conditions
 	 *
 	 */
-	private static class OptimizerVisitor implements OLVisitor {
+	private static class OptimizerVisitor implements VoidOLVisitor {
 		private final List< OLSyntaxNode > programChildren = new ArrayList<>();
 		private final ParsingContext context;
 		private OLSyntaxNode currNode;

--- a/libjolie/src/main/java/jolie/lang/parse/OLParseTreeOptimizer.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParseTreeOptimizer.java
@@ -124,7 +124,7 @@ public class OLParseTreeOptimizer {
 	 * TODO Optimize expressions and conditions
 	 *
 	 */
-	private static class OptimizerVisitor implements VoidOLVisitor {
+	private static class OptimizerVisitor implements UnitOLVisitor {
 		private final List< OLSyntaxNode > programChildren = new ArrayList<>();
 		private final ParsingContext context;
 		private OLSyntaxNode currNode;

--- a/libjolie/src/main/java/jolie/lang/parse/OLVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLVisitor.java
@@ -104,170 +104,177 @@ import jolie.lang.parse.ast.types.TypeChoiceDefinition;
 import jolie.lang.parse.ast.types.TypeDefinitionLink;
 import jolie.lang.parse.ast.types.TypeInlineDefinition;
 
-public interface OLVisitor {
-	default void go( OLSyntaxNode n ) {
-		n.accept( this );
+/**
+ * A generic visitor for the jolie AST.
+ *
+ * @param <C> The type of the context carried along the visit
+ * @param <R> The return type of the visit
+ */
+
+public interface OLVisitor< C, R > {
+	default R go( OLSyntaxNode n, C ctx ) {
+		return n.accept( this, ctx );
 	}
 
-	void visit( Program n );
+	R visit( Program n, C ctx );
 
-	void visit( OneWayOperationDeclaration decl );
+	R visit( OneWayOperationDeclaration decl, C ctx );
 
-	void visit( RequestResponseOperationDeclaration decl );
+	R visit( RequestResponseOperationDeclaration decl, C ctx );
 
-	void visit( DefinitionNode n );
+	R visit( DefinitionNode n, C ctx );
 
-	void visit( ParallelStatement n );
+	R visit( ParallelStatement n, C ctx );
 
-	void visit( SequenceStatement n );
+	R visit( SequenceStatement n, C ctx );
 
-	void visit( NDChoiceStatement n );
+	R visit( NDChoiceStatement n, C ctx );
 
-	void visit( OneWayOperationStatement n );
+	R visit( OneWayOperationStatement n, C ctx );
 
-	void visit( RequestResponseOperationStatement n );
+	R visit( RequestResponseOperationStatement n, C ctx );
 
-	void visit( NotificationOperationStatement n );
+	R visit( NotificationOperationStatement n, C ctx );
 
-	void visit( SolicitResponseOperationStatement n );
+	R visit( SolicitResponseOperationStatement n, C ctx );
 
-	void visit( LinkInStatement n );
+	R visit( LinkInStatement n, C ctx );
 
-	void visit( LinkOutStatement n );
+	R visit( LinkOutStatement n, C ctx );
 
-	void visit( AssignStatement n );
+	R visit( AssignStatement n, C ctx );
 
-	void visit( AddAssignStatement n );
+	R visit( AddAssignStatement n, C ctx );
 
-	void visit( SubtractAssignStatement n );
+	R visit( SubtractAssignStatement n, C ctx );
 
-	void visit( MultiplyAssignStatement n );
+	R visit( MultiplyAssignStatement n, C ctx );
 
-	void visit( DivideAssignStatement n );
+	R visit( DivideAssignStatement n, C ctx );
 
-	void visit( IfStatement n );
+	R visit( IfStatement n, C ctx );
 
-	void visit( DefinitionCallStatement n );
+	R visit( DefinitionCallStatement n, C ctx );
 
-	void visit( WhileStatement n );
+	R visit( WhileStatement n, C ctx );
 
-	void visit( OrConditionNode n );
+	R visit( OrConditionNode n, C ctx );
 
-	void visit( AndConditionNode n );
+	R visit( AndConditionNode n, C ctx );
 
-	void visit( NotExpressionNode n );
+	R visit( NotExpressionNode n, C ctx );
 
-	void visit( CompareConditionNode n );
+	R visit( CompareConditionNode n, C ctx );
 
-	void visit( ConstantIntegerExpression n );
+	R visit( ConstantIntegerExpression n, C ctx );
 
-	void visit( ConstantDoubleExpression n );
+	R visit( ConstantDoubleExpression n, C ctx );
 
-	void visit( ConstantBoolExpression n );
+	R visit( ConstantBoolExpression n, C ctx );
 
-	void visit( ConstantLongExpression n );
+	R visit( ConstantLongExpression n, C ctx );
 
-	void visit( ConstantStringExpression n );
+	R visit( ConstantStringExpression n, C ctx );
 
-	void visit( ProductExpressionNode n );
+	R visit( ProductExpressionNode n, C ctx );
 
-	void visit( SumExpressionNode n );
+	R visit( SumExpressionNode n, C ctx );
 
-	void visit( VariableExpressionNode n );
+	R visit( VariableExpressionNode n, C ctx );
 
-	void visit( NullProcessStatement n );
+	R visit( NullProcessStatement n, C ctx );
 
-	void visit( Scope n );
+	R visit( Scope n, C ctx );
 
-	void visit( InstallStatement n );
+	R visit( InstallStatement n, C ctx );
 
-	void visit( CompensateStatement n );
+	R visit( CompensateStatement n, C ctx );
 
-	void visit( ThrowStatement n );
+	R visit( ThrowStatement n, C ctx );
 
-	void visit( ExitStatement n );
+	R visit( ExitStatement n, C ctx );
 
-	void visit( ExecutionInfo n );
+	R visit( ExecutionInfo n, C ctx );
 
-	void visit( CorrelationSetInfo n );
+	R visit( CorrelationSetInfo n, C ctx );
 
-	void visit( InputPortInfo n );
+	R visit( InputPortInfo n, C ctx );
 
-	void visit( OutputPortInfo n );
+	R visit( OutputPortInfo n, C ctx );
 
-	void visit( PointerStatement n );
+	R visit( PointerStatement n, C ctx );
 
-	void visit( DeepCopyStatement n );
+	R visit( DeepCopyStatement n, C ctx );
 
-	void visit( RunStatement n );
+	R visit( RunStatement n, C ctx );
 
-	void visit( UndefStatement n );
+	R visit( UndefStatement n, C ctx );
 
-	void visit( ValueVectorSizeExpressionNode n );
+	R visit( ValueVectorSizeExpressionNode n, C ctx );
 
-	void visit( PreIncrementStatement n );
+	R visit( PreIncrementStatement n, C ctx );
 
-	void visit( PostIncrementStatement n );
+	R visit( PostIncrementStatement n, C ctx );
 
-	void visit( PreDecrementStatement n );
+	R visit( PreDecrementStatement n, C ctx );
 
-	void visit( PostDecrementStatement n );
+	R visit( PostDecrementStatement n, C ctx );
 
-	void visit( ForStatement n );
+	R visit( ForStatement n, C ctx );
 
-	void visit( ForEachSubNodeStatement n );
+	R visit( ForEachSubNodeStatement n, C ctx );
 
-	void visit( ForEachArrayItemStatement n );
+	R visit( ForEachArrayItemStatement n, C ctx );
 
-	void visit( SpawnStatement n );
+	R visit( SpawnStatement n, C ctx );
 
-	void visit( IsTypeExpressionNode n );
+	R visit( IsTypeExpressionNode n, C ctx );
 
-	void visit( InstanceOfExpressionNode n );
+	R visit( InstanceOfExpressionNode n, C ctx );
 
-	void visit( TypeCastExpressionNode n );
+	R visit( TypeCastExpressionNode n, C ctx );
 
-	void visit( SynchronizedStatement n );
+	R visit( SynchronizedStatement n, C ctx );
 
-	void visit( CurrentHandlerStatement n );
+	R visit( CurrentHandlerStatement n, C ctx );
 
-	void visit( EmbeddedServiceNode n );
+	R visit( EmbeddedServiceNode n, C ctx );
 
-	void visit( InstallFixedVariableExpressionNode n );
+	R visit( InstallFixedVariableExpressionNode n, C ctx );
 
-	void visit( VariablePathNode n );
+	R visit( VariablePathNode n, C ctx );
 
-	void visit( TypeInlineDefinition n );
+	R visit( TypeInlineDefinition n, C ctx );
 
-	void visit( TypeDefinitionLink n );
+	R visit( TypeDefinitionLink n, C ctx );
 
-	void visit( InterfaceDefinition n );
+	R visit( InterfaceDefinition n, C ctx );
 
-	void visit( DocumentationComment n );
+	R visit( DocumentationComment n, C ctx );
 
-	void visit( FreshValueExpressionNode n );
+	R visit( FreshValueExpressionNode n, C ctx );
 
-	void visit( CourierDefinitionNode n );
+	R visit( CourierDefinitionNode n, C ctx );
 
-	void visit( CourierChoiceStatement n );
+	R visit( CourierChoiceStatement n, C ctx );
 
-	void visit( NotificationForwardStatement n );
+	R visit( NotificationForwardStatement n, C ctx );
 
-	void visit( SolicitResponseForwardStatement n );
+	R visit( SolicitResponseForwardStatement n, C ctx );
 
-	void visit( InterfaceExtenderDefinition n );
+	R visit( InterfaceExtenderDefinition n, C ctx );
 
-	void visit( InlineTreeExpressionNode n );
+	R visit( InlineTreeExpressionNode n, C ctx );
 
-	void visit( VoidExpressionNode n );
+	R visit( VoidExpressionNode n, C ctx );
 
-	void visit( ProvideUntilStatement n );
+	R visit( ProvideUntilStatement n, C ctx );
 
-	void visit( TypeChoiceDefinition n );
+	R visit( TypeChoiceDefinition n, C ctx );
 
-	void visit( ImportStatement n );
+	R visit( ImportStatement n, C ctx );
 
-	void visit( ServiceNode n );
+	R visit( ServiceNode n, C ctx );
 
-	void visit( EmbedServiceNode n );
+	R visit( EmbedServiceNode n, C ctx );
 }

--- a/libjolie/src/main/java/jolie/lang/parse/OLVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLVisitor.java
@@ -1,23 +1,22 @@
-/***************************************************************************
- *   Copyright (C) by Fabrizio Montesi                                     *
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU Library General Public License as       *
- *   published by the Free Software Foundation; either version 2 of the    *
- *   License, or (at your option) any later version.                       *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this program; if not, write to the                 *
- *   Free Software Foundation, Inc.,                                       *
- *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
- *                                                                         *
- *   For details about the authors of this software, see the AUTHORS file. *
- ***************************************************************************/
+/*
+ * Copyright (C) 2006-2020 Fabrizio Montesi <famontesi@gmail.com>
+ * Copyright (C) 2020 Valentino Picotti <valentino.picotti@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
 
 package jolie.lang.parse;
 

--- a/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
+++ b/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
@@ -138,7 +138,7 @@ import jolie.util.Pair;
  * @see Program
  * @author Fabrizio Montesi
  */
-public class SemanticVerifier implements OLVisitor {
+public class SemanticVerifier implements VoidOLVisitor {
 	public static class Configuration {
 		private boolean checkForMain = true;
 		private final String executionTarget;

--- a/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
+++ b/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
@@ -138,7 +138,7 @@ import jolie.util.Pair;
  * @see Program
  * @author Fabrizio Montesi
  */
-public class SemanticVerifier implements VoidOLVisitor {
+public class SemanticVerifier implements UnitOLVisitor {
 	public static class Configuration {
 		private boolean checkForMain = true;
 		private final String executionTarget;

--- a/libjolie/src/main/java/jolie/lang/parse/TypeChecker.java
+++ b/libjolie/src/main/java/jolie/lang/parse/TypeChecker.java
@@ -121,7 +121,7 @@ import jolie.util.Pair;
  *
  * @author Fabrizio Montesi
  */
-public class TypeChecker implements VoidOLVisitor {
+public class TypeChecker implements UnitOLVisitor {
 	private static class FlaggedVariablePathNode extends VariablePathNode {
 		private static final long serialVersionUID = Constants.serialVersionUID();
 		private final boolean isFresh;

--- a/libjolie/src/main/java/jolie/lang/parse/TypeChecker.java
+++ b/libjolie/src/main/java/jolie/lang/parse/TypeChecker.java
@@ -121,7 +121,7 @@ import jolie.util.Pair;
  *
  * @author Fabrizio Montesi
  */
-public class TypeChecker implements OLVisitor {
+public class TypeChecker implements VoidOLVisitor {
 	private static class FlaggedVariablePathNode extends VariablePathNode {
 		private static final long serialVersionUID = Constants.serialVersionUID();
 		private final boolean isFresh;

--- a/libjolie/src/main/java/jolie/lang/parse/UnitOLVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/UnitOLVisitor.java
@@ -1,23 +1,22 @@
-/***************************************************************************
- *   Copyright (C) by Fabrizio Montesi                                     *
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU Library General Public License as       *
- *   published by the Free Software Foundation; either version 2 of the    *
- *   License, or (at your option) any later version.                       *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this program; if not, write to the                 *
- *   Free Software Foundation, Inc.,                                       *
- *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
- *                                                                         *
- *   For details about the authors of this software, see the AUTHORS file. *
- ***************************************************************************/
+/*
+ * Copyright (C) 2006-2020 Fabrizio Montesi <famontesi@gmail.com>
+ * Copyright (C) 2020 Valentino Picotti <valentino.picotti@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
 
 package jolie.lang.parse;
 
@@ -105,7 +104,7 @@ import jolie.lang.parse.ast.types.TypeChoiceDefinition;
 import jolie.lang.parse.ast.types.TypeDefinitionLink;
 import jolie.lang.parse.ast.types.TypeInlineDefinition;
 
-public interface VoidOLVisitor extends OLVisitor< Unit, Unit > {
+public interface UnitOLVisitor extends OLVisitor< Unit, Unit > {
 	default void go( OLSyntaxNode n ) {
 		n.accept( this );
 	}
@@ -114,566 +113,566 @@ public interface VoidOLVisitor extends OLVisitor< Unit, Unit > {
 
 	default Unit visit( Program n, Unit c ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( OneWayOperationDeclaration decl );
 
 	default Unit visit( OneWayOperationDeclaration decl, Unit ctx ) {
 		visit( decl );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( RequestResponseOperationDeclaration decl );
 
 	default Unit visit( RequestResponseOperationDeclaration decl, Unit ctx ) {
 		visit( decl );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( DefinitionNode n );
 
 	default Unit visit( DefinitionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ParallelStatement n );
 
 	default Unit visit( ParallelStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( SequenceStatement n );
 
 	default Unit visit( SequenceStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( NDChoiceStatement n );
 
 	default Unit visit( NDChoiceStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( OneWayOperationStatement n );
 
 	default Unit visit( OneWayOperationStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( RequestResponseOperationStatement n );
 
 	default Unit visit( RequestResponseOperationStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( NotificationOperationStatement n );
 
 	default Unit visit( NotificationOperationStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( SolicitResponseOperationStatement n );
 
 	default Unit visit( SolicitResponseOperationStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( LinkInStatement n );
 
 	default Unit visit( LinkInStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( LinkOutStatement n );
 
 	default Unit visit( LinkOutStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( AssignStatement n );
 
 	default Unit visit( AssignStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( AddAssignStatement n );
 
 	default Unit visit( AddAssignStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( SubtractAssignStatement n );
 
 	default Unit visit( SubtractAssignStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( MultiplyAssignStatement n );
 
 	default Unit visit( MultiplyAssignStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( DivideAssignStatement n );
 
 	default Unit visit( DivideAssignStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( IfStatement n );
 
 	default Unit visit( IfStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( DefinitionCallStatement n );
 
 	default Unit visit( DefinitionCallStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( WhileStatement n );
 
 	default Unit visit( WhileStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( OrConditionNode n );
 
 	default Unit visit( OrConditionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( AndConditionNode n );
 
 	default Unit visit( AndConditionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( NotExpressionNode n );
 
 	default Unit visit( NotExpressionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( CompareConditionNode n );
 
 	default Unit visit( CompareConditionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ConstantIntegerExpression n );
 
 	default Unit visit( ConstantIntegerExpression n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ConstantDoubleExpression n );
 
 	default Unit visit( ConstantDoubleExpression n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ConstantBoolExpression n );
 
 	default Unit visit( ConstantBoolExpression n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ConstantLongExpression n );
 
 	default Unit visit( ConstantLongExpression n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ConstantStringExpression n );
 
 	default Unit visit( ConstantStringExpression n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ProductExpressionNode n );
 
 	default Unit visit( ProductExpressionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( SumExpressionNode n );
 
 	default Unit visit( SumExpressionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( VariableExpressionNode n );
 
 	default Unit visit( VariableExpressionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( NullProcessStatement n );
 
 	default Unit visit( NullProcessStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( Scope n );
 
 	default Unit visit( Scope n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( InstallStatement n );
 
 	default Unit visit( InstallStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( CompensateStatement n );
 
 	default Unit visit( CompensateStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ThrowStatement n );
 
 	default Unit visit( ThrowStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ExitStatement n );
 
 	default Unit visit( ExitStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ExecutionInfo n );
 
 	default Unit visit( ExecutionInfo n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( CorrelationSetInfo n );
 
 	default Unit visit( CorrelationSetInfo n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( InputPortInfo n );
 
 	default Unit visit( InputPortInfo n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( OutputPortInfo n );
 
 	default Unit visit( OutputPortInfo n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( PointerStatement n );
 
 	default Unit visit( PointerStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( DeepCopyStatement n );
 
 	default Unit visit( DeepCopyStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( RunStatement n );
 
 	default Unit visit( RunStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( UndefStatement n );
 
 	default Unit visit( UndefStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ValueVectorSizeExpressionNode n );
 
 	default Unit visit( ValueVectorSizeExpressionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( PreIncrementStatement n );
 
 	default Unit visit( PreIncrementStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( PostIncrementStatement n );
 
 	default Unit visit( PostIncrementStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( PreDecrementStatement n );
 
 	default Unit visit( PreDecrementStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( PostDecrementStatement n );
 
 	default Unit visit( PostDecrementStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ForStatement n );
 
 	default Unit visit( ForStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ForEachSubNodeStatement n );
 
 	default Unit visit( ForEachSubNodeStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ForEachArrayItemStatement n );
 
 	default Unit visit( ForEachArrayItemStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( SpawnStatement n );
 
 	default Unit visit( SpawnStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( IsTypeExpressionNode n );
 
 	default Unit visit( IsTypeExpressionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( InstanceOfExpressionNode n );
 
 	default Unit visit( InstanceOfExpressionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( TypeCastExpressionNode n );
 
 	default Unit visit( TypeCastExpressionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( SynchronizedStatement n );
 
 	default Unit visit( SynchronizedStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( CurrentHandlerStatement n );
 
 	default Unit visit( CurrentHandlerStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( EmbeddedServiceNode n );
 
 	default Unit visit( EmbeddedServiceNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( InstallFixedVariableExpressionNode n );
 
 	default Unit visit( InstallFixedVariableExpressionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( VariablePathNode n );
 
 	default Unit visit( VariablePathNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( TypeInlineDefinition n );
 
 	default Unit visit( TypeInlineDefinition n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( TypeDefinitionLink n );
 
 	default Unit visit( TypeDefinitionLink n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( InterfaceDefinition n );
 
 	default Unit visit( InterfaceDefinition n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( DocumentationComment n );
 
 	default Unit visit( DocumentationComment n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( FreshValueExpressionNode n );
 
 	default Unit visit( FreshValueExpressionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( CourierDefinitionNode n );
 
 	default Unit visit( CourierDefinitionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( CourierChoiceStatement n );
 
 	default Unit visit( CourierChoiceStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( NotificationForwardStatement n );
 
 	default Unit visit( NotificationForwardStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( SolicitResponseForwardStatement n );
 
 	default Unit visit( SolicitResponseForwardStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( InterfaceExtenderDefinition n );
 
 	default Unit visit( InterfaceExtenderDefinition n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( InlineTreeExpressionNode n );
 
 	default Unit visit( InlineTreeExpressionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( VoidExpressionNode n );
 
 	default Unit visit( VoidExpressionNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ProvideUntilStatement n );
 
 	default Unit visit( ProvideUntilStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( TypeChoiceDefinition n );
 
 	default Unit visit( TypeChoiceDefinition n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ImportStatement n );
 
 	default Unit visit( ImportStatement n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( ServiceNode n );
 
 	default Unit visit( ServiceNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 
 	void visit( EmbedServiceNode n );
 
 	default Unit visit( EmbedServiceNode n, Unit ctx ) {
 		visit( n );
-		return null;
+		return Unit.INSTANCE;
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/AddAssignStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/AddAssignStatement.java
@@ -46,7 +46,7 @@ public class AddAssignStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/AssignStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/AssignStatement.java
@@ -44,7 +44,7 @@ public class AssignStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/CompareConditionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/CompareConditionNode.java
@@ -51,7 +51,7 @@ public class CompareConditionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/CompensateStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/CompensateStatement.java
@@ -38,7 +38,7 @@ public class CompensateStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/CorrelationSetInfo.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/CorrelationSetInfo.java
@@ -83,7 +83,7 @@ public class CorrelationSetInfo extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/CurrentHandlerStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/CurrentHandlerStatement.java
@@ -30,7 +30,7 @@ public class CurrentHandlerStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/DeepCopyStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/DeepCopyStatement.java
@@ -55,7 +55,7 @@ public class DeepCopyStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/DefinitionCallStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/DefinitionCallStatement.java
@@ -38,7 +38,7 @@ public class DefinitionCallStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/DefinitionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/DefinitionNode.java
@@ -44,7 +44,7 @@ public class DefinitionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/DivideAssignStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/DivideAssignStatement.java
@@ -46,7 +46,7 @@ public class DivideAssignStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/DocumentationComment.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/DocumentationComment.java
@@ -41,7 +41,7 @@ public class DocumentationComment extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/EmbedServiceNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/EmbedServiceNode.java
@@ -55,8 +55,8 @@ public class EmbedServiceNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/EmbeddedServiceNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/EmbeddedServiceNode.java
@@ -64,7 +64,7 @@ public class EmbeddedServiceNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/ExecutionInfo.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/ExecutionInfo.java
@@ -38,7 +38,7 @@ public class ExecutionInfo extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/ExitStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/ExitStatement.java
@@ -30,7 +30,7 @@ public class ExitStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/ForEachArrayItemStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/ForEachArrayItemStatement.java
@@ -63,7 +63,7 @@ public class ForEachArrayItemStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/ForEachSubNodeStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/ForEachSubNodeStatement.java
@@ -53,7 +53,7 @@ public class ForEachSubNodeStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/ForStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/ForStatement.java
@@ -58,7 +58,7 @@ public class ForStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/IfStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/IfStatement.java
@@ -57,7 +57,7 @@ public class IfStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/ImportStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/ImportStatement.java
@@ -125,7 +125,7 @@ public class ImportStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/InputPortInfo.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/InputPortInfo.java
@@ -81,8 +81,8 @@ public class InputPortInfo extends PortInfo {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 
 	public String protocolId() {

--- a/libjolie/src/main/java/jolie/lang/parse/ast/InstallFixedVariableExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/InstallFixedVariableExpressionNode.java
@@ -38,7 +38,7 @@ public class InstallFixedVariableExpressionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/InstallStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/InstallStatement.java
@@ -38,7 +38,7 @@ public class InstallStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/InterfaceDefinition.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/InterfaceDefinition.java
@@ -68,8 +68,8 @@ public class InterfaceDefinition extends OLSyntaxNode
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/ast/InterfaceExtenderDefinition.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/InterfaceExtenderDefinition.java
@@ -37,8 +37,8 @@ public class InterfaceExtenderDefinition extends InterfaceDefinition {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 
 	public OneWayOperationDeclaration defaultOneWayOperation() {

--- a/libjolie/src/main/java/jolie/lang/parse/ast/LinkInStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/LinkInStatement.java
@@ -38,7 +38,7 @@ public class LinkInStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/LinkOutStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/LinkOutStatement.java
@@ -38,7 +38,7 @@ public class LinkOutStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/MultiplyAssignStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/MultiplyAssignStatement.java
@@ -46,7 +46,7 @@ public class MultiplyAssignStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/NDChoiceStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/NDChoiceStatement.java
@@ -47,7 +47,7 @@ public class NDChoiceStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/NotificationOperationStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/NotificationOperationStatement.java
@@ -53,7 +53,7 @@ public class NotificationOperationStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/NullProcessStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/NullProcessStatement.java
@@ -30,7 +30,7 @@ public class NullProcessStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/OLSyntaxNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/OLSyntaxNode.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 
 import jolie.lang.Constants;
 import jolie.lang.parse.OLVisitor;
+import jolie.util.Unit;
 import jolie.lang.parse.context.ParsingContext;
 
 public abstract class OLSyntaxNode implements Serializable {
@@ -40,5 +41,11 @@ public abstract class OLSyntaxNode implements Serializable {
 		return context;
 	}
 
-	abstract public void accept( OLVisitor visitor );
+	// abstract public < C, R > void accept( OLVisitor visitor );
+
+	abstract public < C, R > R accept( OLVisitor< C, R > v, C ctx );
+
+	public < R > R accept( OLVisitor< Unit, R > v ) {
+		return accept( v, null );
+	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/OLSyntaxNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/OLSyntaxNode.java
@@ -25,8 +25,8 @@ import java.io.Serializable;
 
 import jolie.lang.Constants;
 import jolie.lang.parse.OLVisitor;
-import jolie.util.Unit;
 import jolie.lang.parse.context.ParsingContext;
+import jolie.util.Unit;
 
 public abstract class OLSyntaxNode implements Serializable {
 	private static final long serialVersionUID = Constants.serialVersionUID();
@@ -41,11 +41,9 @@ public abstract class OLSyntaxNode implements Serializable {
 		return context;
 	}
 
-	// abstract public < C, R > void accept( OLVisitor visitor );
-
 	abstract public < C, R > R accept( OLVisitor< C, R > v, C ctx );
 
 	public < R > R accept( OLVisitor< Unit, R > v ) {
-		return accept( v, null );
+		return accept( v, Unit.INSTANCE );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/OneWayOperationDeclaration.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/OneWayOperationDeclaration.java
@@ -43,7 +43,7 @@ public class OneWayOperationDeclaration extends OperationDeclaration {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/OneWayOperationStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/OneWayOperationStatement.java
@@ -44,7 +44,7 @@ public class OneWayOperationStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/OutputPortInfo.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/OutputPortInfo.java
@@ -42,8 +42,8 @@ public class OutputPortInfo extends PortInfo {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 
 	public OLSyntaxNode protocol() {

--- a/libjolie/src/main/java/jolie/lang/parse/ast/ParallelStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/ParallelStatement.java
@@ -46,7 +46,7 @@ public class ParallelStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/PointerStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/PointerStatement.java
@@ -44,7 +44,7 @@ public class PointerStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/PostDecrementStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/PostDecrementStatement.java
@@ -38,7 +38,7 @@ public class PostDecrementStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/PostIncrementStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/PostIncrementStatement.java
@@ -38,7 +38,7 @@ public class PostIncrementStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/PreDecrementStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/PreDecrementStatement.java
@@ -38,7 +38,7 @@ public class PreDecrementStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/PreIncrementStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/PreIncrementStatement.java
@@ -38,7 +38,7 @@ public class PreIncrementStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/Program.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/Program.java
@@ -45,7 +45,7 @@ public class Program extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/ProvideUntilStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/ProvideUntilStatement.java
@@ -43,7 +43,7 @@ public class ProvideUntilStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/RequestResponseOperationDeclaration.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/RequestResponseOperationDeclaration.java
@@ -58,7 +58,7 @@ public class RequestResponseOperationDeclaration extends OperationDeclaration {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/RequestResponseOperationStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/RequestResponseOperationStatement.java
@@ -60,7 +60,7 @@ public class RequestResponseOperationStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/RunStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/RunStatement.java
@@ -38,7 +38,7 @@ public class RunStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/Scope.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/Scope.java
@@ -44,7 +44,7 @@ public class Scope extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/SequenceStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/SequenceStatement.java
@@ -46,7 +46,7 @@ public class SequenceStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/ServiceNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/ServiceNode.java
@@ -117,8 +117,8 @@ public class ServiceNode extends OLSyntaxNode implements ImportableSymbol {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > v, C ctx ) {
+		return v.visit( this, ctx );
 	}
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/ast/SolicitResponseOperationStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/SolicitResponseOperationStatement.java
@@ -67,7 +67,7 @@ public class SolicitResponseOperationStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/SpawnStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/SpawnStatement.java
@@ -60,7 +60,7 @@ public class SpawnStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/SubtractAssignStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/SubtractAssignStatement.java
@@ -25,7 +25,7 @@ public class SubtractAssignStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/SynchronizedStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/SynchronizedStatement.java
@@ -44,7 +44,7 @@ public class SynchronizedStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/ThrowStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/ThrowStatement.java
@@ -50,7 +50,7 @@ public class ThrowStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/TypeCastExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/TypeCastExpressionNode.java
@@ -45,7 +45,7 @@ public class TypeCastExpressionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/UndefStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/UndefStatement.java
@@ -38,7 +38,7 @@ public class UndefStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/ValueVectorSizeExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/ValueVectorSizeExpressionNode.java
@@ -38,7 +38,7 @@ public class ValueVectorSizeExpressionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/VariablePathNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/VariablePathNode.java
@@ -106,8 +106,8 @@ public class VariablePathNode extends OLSyntaxNode implements Serializable {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 
 	public boolean isEquivalentTo( VariablePathNode right ) {

--- a/libjolie/src/main/java/jolie/lang/parse/ast/WhileStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/WhileStatement.java
@@ -43,7 +43,7 @@ public class WhileStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/courier/CourierChoiceStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/courier/CourierChoiceStatement.java
@@ -136,7 +136,7 @@ public class CourierChoiceStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/courier/CourierDefinitionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/courier/CourierDefinitionNode.java
@@ -44,7 +44,7 @@ public class CourierDefinitionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/courier/NotificationForwardStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/courier/NotificationForwardStatement.java
@@ -50,7 +50,7 @@ public class NotificationForwardStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/courier/SolicitResponseForwardStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/courier/SolicitResponseForwardStatement.java
@@ -57,7 +57,7 @@ public class SolicitResponseForwardStatement extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/AndConditionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/AndConditionNode.java
@@ -44,7 +44,7 @@ public class AndConditionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/ConstantBoolExpression.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/ConstantBoolExpression.java
@@ -37,7 +37,7 @@ public class ConstantBoolExpression extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/ConstantDoubleExpression.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/ConstantDoubleExpression.java
@@ -37,7 +37,7 @@ public class ConstantDoubleExpression extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/ConstantIntegerExpression.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/ConstantIntegerExpression.java
@@ -38,7 +38,7 @@ public class ConstantIntegerExpression extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/ConstantLongExpression.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/ConstantLongExpression.java
@@ -38,7 +38,7 @@ public class ConstantLongExpression extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/ConstantStringExpression.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/ConstantStringExpression.java
@@ -38,8 +38,8 @@ public class ConstantStringExpression extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/FreshValueExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/FreshValueExpressionNode.java
@@ -30,7 +30,7 @@ public class FreshValueExpressionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/InlineTreeExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/InlineTreeExpressionNode.java
@@ -106,7 +106,7 @@ public class InlineTreeExpressionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/InstanceOfExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/InstanceOfExpressionNode.java
@@ -44,7 +44,7 @@ public class InstanceOfExpressionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/IsTypeExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/IsTypeExpressionNode.java
@@ -48,7 +48,7 @@ public class IsTypeExpressionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/NotExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/NotExpressionNode.java
@@ -37,7 +37,7 @@ public class NotExpressionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/OrConditionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/OrConditionNode.java
@@ -45,7 +45,7 @@ public class OrConditionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/ProductExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/ProductExpressionNode.java
@@ -56,7 +56,7 @@ public class ProductExpressionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/SumExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/SumExpressionNode.java
@@ -52,7 +52,7 @@ public class SumExpressionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/VariableExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/VariableExpressionNode.java
@@ -38,8 +38,8 @@ public class VariableExpressionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/VoidExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/VoidExpressionNode.java
@@ -30,7 +30,7 @@ public class VoidExpressionNode extends OLSyntaxNode {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 }

--- a/libjolie/src/main/java/jolie/lang/parse/ast/types/TypeChoiceDefinition.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/types/TypeChoiceDefinition.java
@@ -47,8 +47,8 @@ public class TypeChoiceDefinition extends TypeDefinition {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 
 	public TypeDefinition left() {

--- a/libjolie/src/main/java/jolie/lang/parse/ast/types/TypeDefinitionLink.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/types/TypeDefinitionLink.java
@@ -93,8 +93,8 @@ public class TypeDefinitionLink extends TypeDefinition {
 	 */
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/ast/types/TypeInlineDefinition.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/types/TypeInlineDefinition.java
@@ -121,8 +121,8 @@ public class TypeInlineDefinition extends TypeDefinition {
 	}
 
 	@Override
-	public void accept( OLVisitor visitor ) {
-		visitor.visit( this );
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
 	}
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
@@ -25,7 +25,7 @@ import java.util.*;
 import jolie.lang.CodeCheckingError;
 import jolie.lang.Constants;
 import jolie.lang.Constants.OperandType;
-import jolie.lang.parse.OLVisitor;
+import jolie.lang.parse.VoidOLVisitor;
 import jolie.lang.parse.ast.AddAssignStatement;
 import jolie.lang.parse.ast.AssignStatement;
 import jolie.lang.parse.ast.CompareConditionNode;
@@ -162,7 +162,7 @@ public class SymbolReferenceResolver {
 	// + " has infinite loop to it's linked type" );
 	// }
 
-	private class SymbolReferenceResolverVisitor implements OLVisitor {
+	private class SymbolReferenceResolverVisitor implements VoidOLVisitor {
 		private URI currentURI;
 		private final List< CodeCheckingError > errors = new ArrayList<>();
 

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
@@ -25,7 +25,7 @@ import java.util.*;
 import jolie.lang.CodeCheckingError;
 import jolie.lang.Constants;
 import jolie.lang.Constants.OperandType;
-import jolie.lang.parse.VoidOLVisitor;
+import jolie.lang.parse.UnitOLVisitor;
 import jolie.lang.parse.ast.AddAssignStatement;
 import jolie.lang.parse.ast.AssignStatement;
 import jolie.lang.parse.ast.CompareConditionNode;
@@ -162,7 +162,7 @@ public class SymbolReferenceResolver {
 	// + " has infinite loop to it's linked type" );
 	// }
 
-	private class SymbolReferenceResolverVisitor implements VoidOLVisitor {
+	private class SymbolReferenceResolverVisitor implements UnitOLVisitor {
 		private URI currentURI;
 		private final List< CodeCheckingError > errors = new ArrayList<>();
 

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
@@ -21,7 +21,7 @@ package jolie.lang.parse.module;
 
 import java.util.Map;
 import jolie.lang.NativeType;
-import jolie.lang.parse.VoidOLVisitor;
+import jolie.lang.parse.UnitOLVisitor;
 import jolie.lang.parse.ast.AddAssignStatement;
 import jolie.lang.parse.ast.AssignStatement;
 import jolie.lang.parse.ast.CompareConditionNode;
@@ -112,7 +112,7 @@ import jolie.lang.parse.module.exceptions.DuplicateSymbolException;
 
 public class SymbolTableGenerator {
 
-	private static class SymbolTableGeneratorVisitor implements VoidOLVisitor {
+	private static class SymbolTableGeneratorVisitor implements UnitOLVisitor {
 		private final SymbolTable symbolTable;
 		private boolean valid = true;
 		private ModuleException error;

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
@@ -21,7 +21,7 @@ package jolie.lang.parse.module;
 
 import java.util.Map;
 import jolie.lang.NativeType;
-import jolie.lang.parse.OLVisitor;
+import jolie.lang.parse.VoidOLVisitor;
 import jolie.lang.parse.ast.AddAssignStatement;
 import jolie.lang.parse.ast.AssignStatement;
 import jolie.lang.parse.ast.CompareConditionNode;
@@ -112,7 +112,7 @@ import jolie.lang.parse.module.exceptions.DuplicateSymbolException;
 
 public class SymbolTableGenerator {
 
-	private static class SymbolTableGeneratorVisitor implements OLVisitor {
+	private static class SymbolTableGeneratorVisitor implements VoidOLVisitor {
 		private final SymbolTable symbolTable;
 		private boolean valid = true;
 		private ModuleException error;

--- a/libjolie/src/main/java/jolie/lang/parse/util/impl/ProgramInspectorCreatorVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/util/impl/ProgramInspectorCreatorVisitor.java
@@ -29,7 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import jolie.lang.parse.OLVisitor;
+import jolie.lang.parse.VoidOLVisitor;
 import jolie.lang.parse.ast.AddAssignStatement;
 import jolie.lang.parse.ast.AssignStatement;
 import jolie.lang.parse.ast.CompareConditionNode;
@@ -121,7 +121,7 @@ import jolie.util.Pair;
  * 
  * @author Fabrizio Montesi
  */
-public class ProgramInspectorCreatorVisitor implements OLVisitor {
+public class ProgramInspectorCreatorVisitor implements VoidOLVisitor {
 	private final Map< URI, List< InterfaceDefinition > > interfaces = new HashMap<>();
 	private final Map< URI, List< InputPortInfo > > inputPorts = new HashMap<>();
 	private final Map< URI, List< OutputPortInfo > > outputPorts = new HashMap<>();

--- a/libjolie/src/main/java/jolie/lang/parse/util/impl/ProgramInspectorCreatorVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/util/impl/ProgramInspectorCreatorVisitor.java
@@ -29,7 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import jolie.lang.parse.VoidOLVisitor;
+import jolie.lang.parse.UnitOLVisitor;
 import jolie.lang.parse.ast.AddAssignStatement;
 import jolie.lang.parse.ast.AssignStatement;
 import jolie.lang.parse.ast.CompareConditionNode;
@@ -121,7 +121,7 @@ import jolie.util.Pair;
  * 
  * @author Fabrizio Montesi
  */
-public class ProgramInspectorCreatorVisitor implements VoidOLVisitor {
+public class ProgramInspectorCreatorVisitor implements UnitOLVisitor {
 	private final Map< URI, List< InterfaceDefinition > > interfaces = new HashMap<>();
 	private final Map< URI, List< InputPortInfo > > inputPorts = new HashMap<>();
 	private final Map< URI, List< OutputPortInfo > > outputPorts = new HashMap<>();

--- a/libjolie/src/main/java/jolie/util/Unit.java
+++ b/libjolie/src/main/java/jolie/util/Unit.java
@@ -1,8 +1,30 @@
+/*
+ * Copyright (C) 2006-2020 Fabrizio Montesi <famontesi@gmail.com>
+ * Copyright (C) 2020 Valentino Picotti <valentino.picotti@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
 package jolie.util;
 
 /**
- * Unit is a type with only one inhabitant, the <code>null</code> value.
+ * Unit is a type with only one inhabitant, the <code>Unit.INSTANCE</code> value.
  */
 public final class Unit {
+	public static final Unit INSTANCE = new Unit();
+
 	private Unit() {}
 }

--- a/libjolie/src/main/java/jolie/util/Unit.java
+++ b/libjolie/src/main/java/jolie/util/Unit.java
@@ -1,0 +1,8 @@
+package jolie.util;
+
+/**
+ * Unit is a type with only one inhabitant, the <code>null</code> value.
+ */
+public final class Unit {
+	private Unit() {}
+}

--- a/libjolie/src/main/java/jolie/util/Unit.java
+++ b/libjolie/src/main/java/jolie/util/Unit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2020 Fabrizio Montesi <famontesi@gmail.com>
+ * Copyright (C) 2020 Fabrizio Montesi <famontesi@gmail.com>
  * Copyright (C) 2020 Valentino Picotti <valentino.picotti@gmail.com>
  *
  * This library is free software; you can redistribute it and/or

--- a/tools/jolie2java/src/main/java/joliex/java/impl/InterfaceVisitor.java
+++ b/tools/jolie2java/src/main/java/joliex/java/impl/InterfaceVisitor.java
@@ -23,7 +23,7 @@ package joliex.java.impl;
 
 import java.util.*;
 
-import jolie.lang.parse.OLVisitor;
+import jolie.lang.parse.VoidOLVisitor;
 import jolie.lang.parse.ast.AddAssignStatement;
 import jolie.lang.parse.ast.AssignStatement;
 import jolie.lang.parse.ast.CompareConditionNode;
@@ -111,7 +111,7 @@ import jolie.lang.parse.ast.types.TypeInlineDefinition;
  *
  * @author Fabrizio Montesi
  */
-public class InterfaceVisitor implements OLVisitor {
+public class InterfaceVisitor implements VoidOLVisitor {
 	private final Program program;
 	private final List< InterfaceDefinition > interfaceDefinitions =
 		new ArrayList<>();

--- a/tools/jolie2java/src/main/java/joliex/java/impl/InterfaceVisitor.java
+++ b/tools/jolie2java/src/main/java/joliex/java/impl/InterfaceVisitor.java
@@ -23,7 +23,7 @@ package joliex.java.impl;
 
 import java.util.*;
 
-import jolie.lang.parse.VoidOLVisitor;
+import jolie.lang.parse.UnitOLVisitor;
 import jolie.lang.parse.ast.AddAssignStatement;
 import jolie.lang.parse.ast.AssignStatement;
 import jolie.lang.parse.ast.CompareConditionNode;
@@ -111,7 +111,7 @@ import jolie.lang.parse.ast.types.TypeInlineDefinition;
  *
  * @author Fabrizio Montesi
  */
-public class InterfaceVisitor implements VoidOLVisitor {
+public class InterfaceVisitor implements UnitOLVisitor {
 	private final Program program;
 	private final List< InterfaceDefinition > interfaceDefinitions =
 		new ArrayList<>();

--- a/tools/jolie2plasma/src/main/java/joliex/plasma/impl/InterfaceVisitor.java
+++ b/tools/jolie2plasma/src/main/java/joliex/plasma/impl/InterfaceVisitor.java
@@ -23,7 +23,7 @@ package joliex.plasma.impl;
 
 import java.util.*;
 
-import jolie.lang.parse.VoidOLVisitor;
+import jolie.lang.parse.UnitOLVisitor;
 import jolie.lang.parse.ast.AddAssignStatement;
 import jolie.lang.parse.ast.AssignStatement;
 import jolie.lang.parse.ast.CompareConditionNode;
@@ -111,7 +111,7 @@ import jolie.lang.parse.ast.types.TypeInlineDefinition;
  *
  * @author Fabrizio Montesi
  */
-public class InterfaceVisitor implements VoidOLVisitor {
+public class InterfaceVisitor implements UnitOLVisitor {
 	private final Program program;
 	private final List< InterfaceDefinition > interfaceDefinitions =
 		new ArrayList<>();

--- a/tools/jolie2plasma/src/main/java/joliex/plasma/impl/InterfaceVisitor.java
+++ b/tools/jolie2plasma/src/main/java/joliex/plasma/impl/InterfaceVisitor.java
@@ -23,7 +23,7 @@ package joliex.plasma.impl;
 
 import java.util.*;
 
-import jolie.lang.parse.OLVisitor;
+import jolie.lang.parse.VoidOLVisitor;
 import jolie.lang.parse.ast.AddAssignStatement;
 import jolie.lang.parse.ast.AssignStatement;
 import jolie.lang.parse.ast.CompareConditionNode;
@@ -111,7 +111,7 @@ import jolie.lang.parse.ast.types.TypeInlineDefinition;
  *
  * @author Fabrizio Montesi
  */
-public class InterfaceVisitor implements OLVisitor {
+public class InterfaceVisitor implements VoidOLVisitor {
 	private final Program program;
 	private final List< InterfaceDefinition > interfaceDefinitions =
 		new ArrayList<>();


### PR DESCRIPTION
### Introduced changes
1. `OLVisitor< C, R >` is a generic interface for any visitor of `OLSyntaxNode`. `visit` methods accept an additional argument (a context) of type `C` and return a value of type `R`, making it possible to define *stateless* visitors of the AST.

2. `VoidOLVisitor` extends `OLVisitor< Unit, Unit >` to provide the same interface as the *old* `OLVisitor`. Every visitor now implements `VoidOLVisitor`.
