### PR TITLE
Prohibits duplicate symbol name of a ServiceNode

### DIFF
--- a/libjolie/src/main/java/jolie/lang/parse/OLParser.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParser.java
@@ -141,7 +141,7 @@ public class OLParser extends AbstractParser {
 			programBuilder.addChild( main );
 		}
 
-		if( !programBuilder.isJolieModuleSystem() ) {
+		if( !programBuilder.isJolieModuleSystem() && main != null ) {
 			programBuilder.transformProgramToModuleSystem();
 		} else if( hasIncludeDirective ) {
 			// [backward-compatibility] for include directive, remove Deployment Instructions which was added

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolTable.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolTable.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import jolie.lang.parse.ast.ImportableSymbol;
+import jolie.lang.parse.ast.ServiceNode;
 import jolie.lang.parse.ast.ImportableSymbol.AccessModifier;
 import jolie.lang.parse.context.ParsingContext;
 import jolie.lang.parse.module.SymbolInfo.Scope;
@@ -87,7 +88,10 @@ public class SymbolTable {
 	 */
 	protected void addSymbol( String name, ImportableSymbol node ) throws DuplicateSymbolException {
 		if( isDuplicateSymbol( name ) ) {
-			throw new DuplicateSymbolException( name );
+			if( node instanceof ServiceNode ) {
+				// allows re-declaration of any symbols except ServiceNode.
+				throw new DuplicateSymbolException( name );
+			}
 		}
 		this.symbols.put( name, new LocalSymbolInfo( name, node ) );
 	}
@@ -163,7 +167,7 @@ public class SymbolTable {
 	}
 
 	private boolean isDuplicateSymbol( String name ) {
-		return symbols.containsKey( name ) && symbols.get( name ).scope() != Scope.LOCAL;
+		return symbols.containsKey( name );
 	}
 
 	@Override


### PR DESCRIPTION
This PR eliminates the possibility to create a service node with a conflict name in local environment. 
For backward compatibility issue with include directive, we still allow a re-declaration of other type of symbols.