### PR TITLE
Type.simpleName()

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -189,7 +189,7 @@
       "name": "Tests - CustomFile",
       "request": "launch",
       "mainClass": "jolie.Jolie",
-      "projectName": "jolie",
+      "projectName": "jolie-cli",
       "cwd": "${workspaceFolder}/test",
       "args": [
         "-l",

--- a/libjolie/src/main/java/jolie/lang/parse/module/ModuleFinderImpl.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/ModuleFinderImpl.java
@@ -127,6 +127,10 @@ public class ModuleFinderImpl implements ModuleFinder {
 		for( String packageDir : packageParts ) {
 			basePath = basePath.resolve( packageDir );
 		}
+		if( basePath.resolve( moduleName ).toFile().isDirectory() ) {
+			basePath = basePath.resolve( moduleName );
+			moduleName = "main";
+		}
 		Path olTargetFile = ModuleFinder.olLookup( basePath, moduleName );
 		return new PathSource( olTargetFile );
 	}

--- a/test/primitives/import.ol
+++ b/test/primitives/import.ol
@@ -22,6 +22,7 @@ from .private.imports.point import point as p
 from .private.imports.iface import fooIface
 from .private.imports.namespace import *
 from .private.imports.namespace import n1 as asN1, n2 as asN2
+from .private.imports.pkg import mainDefaultType
 from twice.twice.main import TwiceAPI
 from .packages.t import test
 from .packages.bar.foo import type_foo, type_bar, type_bar_package
@@ -97,5 +98,12 @@ define doTest {
 	bar_pack_val << { bar_sub = "str"}
 	if ( !(bar_pack_val instanceof type_bar_package) ) {
 		throw( TestFailed, "type_bar_package is not imported" )
+	}
+
+	// test default to main.ol
+    m << {zz= "1"}
+
+	if ( !(m instanceof mainDefaultType) ) {
+		throw( TestFailed, "mainDefaultType is not imported" )
 	}
 }

--- a/test/primitives/private/imports/pkg/main.ol
+++ b/test/primitives/private/imports/pkg/main.ol
@@ -1,0 +1,4 @@
+// some type
+type mainDefaultType: void {
+    zz: string
+}


### PR DESCRIPTION
This PR fixes the issue on MetaJolie when inspecting the name of the type which was prefixed during parsing. By implementing type.simpleName() method that will return human-friendly type name to the client. This PR also removes type.id(), which is replaced by type.name().