### PR TITLE
Change wildcard import to individual symbol

### DIFF
--- a/packages/inspector.ol
+++ b/packages/inspector.ol
@@ -18,7 +18,7 @@
  * MA 02110-1301  USA
  */
 
-from types.JavaException import *
+from types.JavaException import WeakJavaExceptionType
 
 type Field {
 	name: string

--- a/packages/message-digest.ol
+++ b/packages/message-digest.ol
@@ -19,7 +19,7 @@
  *   For details about the authors of this software, see the AUTHORS file.
  */
 
-from types.JavaException import *
+from types.JavaException import JavaExceptionType
 type MD5Request:string {
 	.radix?:int
 } | raw {

--- a/packages/message_digest.ol
+++ b/packages/message_digest.ol
@@ -19,7 +19,7 @@
  *   For details about the authors of this software, see the AUTHORS file.
  */
 
-from types.JavaException import *
+from types.JavaException import JavaExceptionType
 type MD5Request:string {
 	.radix?:int
 } | raw {

--- a/packages/reflection.ol
+++ b/packages/reflection.ol
@@ -19,7 +19,7 @@
  *   For details about the authors of this software, see the AUTHORS file.
  */
 
-from types.Binding import *
+from types.Binding import Binding
 
 type InvokeRequest:void {
 	.operation:string 

--- a/packages/smtp.ol
+++ b/packages/smtp.ol
@@ -19,8 +19,6 @@
  *  For details about the authors of this software, see the AUTHORS file.
  */
 
-from types.JavaException import *
-
 type SendMailRequest:void {
 	/* Host & Authentication */
 	.host:string

--- a/packages/web-services-utils.ol
+++ b/packages/web-services-utils.ol
@@ -19,7 +19,7 @@
  *   For details about the authors of this software, see the AUTHORS file. 
  */
 
-from types.IOException import *
+from types.IOException import IOExceptionType
 
 interface WebServicesUtilsInterface {
 RequestResponse:

--- a/packages/web_services_utils.ol
+++ b/packages/web_services_utils.ol
@@ -19,7 +19,7 @@
  *   For details about the authors of this software, see the AUTHORS file. 
  */
 
-from types.IOException import *
+from types.IOException import IOExceptionType
 
 interface WebServicesUtilsInterface {
 RequestResponse:

--- a/packages/zip-utils.ol
+++ b/packages/zip-utils.ol
@@ -19,7 +19,7 @@
  *   For details about the authors of this software, see the AUTHORS file. 
  */
 
-from types.IOException import *
+from types.IOException import IOExceptionType
 
 type ReadEntryRequest:void {
 	.filename?:string

--- a/packages/zip_utils.ol
+++ b/packages/zip_utils.ol
@@ -19,7 +19,7 @@
  *   For details about the authors of this software, see the AUTHORS file. 
  */
 
-from types.IOException import *
+from types.IOException import IOExceptionType
 
 type ReadEntryRequest:void {
 	.filename?:string


### PR DESCRIPTION
This PR fix an duplicate symbol error that occur when two of these libraries are imported in the same module