### PR TITLE
fix converter tests on Windows

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -68,6 +68,8 @@
 					<executable>${jolie.launcher}</executable>
 					<arguments>
 						<argument>--stackTraces</argument>
+						<argument>--charset</argument>
+						<argument>UTF-8</argument>
 						<argument>test.ol</argument>
 					</arguments>
 				</configuration>


### PR DESCRIPTION
pass the correct encoding parameter for the input files