### PR TITLE
Service File: get the name of the file from which a service has been launched

### DIFF
--- a/javaServices/coreJavaServices/src/main/java/joliex/io/FileService.java
+++ b/javaServices/coreJavaServices/src/main/java/joliex/io/FileService.java
@@ -474,6 +474,21 @@ public class FileService extends JavaService {
 	}
 
 	@RequestResponse
+	public String getServiceFileName() {
+		return Paths.get( interpreter().programFilepath() ).getFileName().toString();
+	}
+
+	@RequestResponse
+	public String getRealServiceFileName()
+		throws FaultException {
+		try {
+			return Paths.get( interpreter().programFilepath() ).toRealPath().getFileName().toString();
+		} catch( IOException e ) {
+			throw new FaultException( "IOException", e );
+		}
+	}
+
+	@RequestResponse
 	public String getFileSeparator() {
 		return jolie.lang.Constants.FILE_SEPARATOR;
 	}

--- a/packages/file.ol
+++ b/packages/file.ol
@@ -191,8 +191,12 @@ RequestResponse:
 
 	/** Returns the filesystem directory from which the service has been launched */
 	getServiceDirectory(void)(string) throws IOException(IOExceptionType),
+	/** Returns the name of the file from which the service has been launched */
+	getServiceFileName(void)(string),
 	/** Returns the real filesystem directory (following links) from which the service has been launched */
 	getRealServiceDirectory(void)(string) throws IOException(IOExceptionType),
+	/** Returns the name of the real file (following links) from which the service has been launched */
+	getRealServiceFileName(void)(string) throws IOException(IOExceptionType),
 	getFileSeparator(void)(string),
 	getMimeType(string)(string) throws FileNotFound(FileNotFoundType),
 	setMimeTypeFile(string)(void) throws IOException(IOExceptionType),


### PR DESCRIPTION
This PR extends the API of the File service with two operations:
- getServiceFileName(void)(string)
- getRealServiceFileName(void)(string)

This is particularly useful for Jolie scripts (Jolie files with the shebang pattern `#!/usr/bin/env jolie`) which must retrieve the name of the file they are defined in, in order to provide good error messages.