### PR TITLE
Fix ArrayIndexOutOfBoundsException on ValuePrettyPrinter

### DIFF
--- a/jolie/src/main/java/jolie/runtime/ValuePrettyPrinter.java
+++ b/jolie/src/main/java/jolie/runtime/ValuePrettyPrinter.java
@@ -155,7 +155,7 @@ public class ValuePrettyPrinter {
 	private void writeIndented( String s, List< Boolean > hasMore )
 		throws IOException {
 		for( int i = 0; i < indentation; i++ ) {
-			if( hasMore.get( i ) ) {
+			if( hasMore.size() > i && hasMore.get( i ) ) {
 				writer.write( '│' );
 			}
 			writer.write( '\t' );


### PR DESCRIPTION
possibly a fix for #359, as I didn't dig much deep for the better fix. But the error raises when `setIndentationOffset` function is called and `indentation` is greater than `hasMore` length. 