### PR TITLE
Fix: OutputPort location can be either a string or a variable expression

### DIFF
--- a/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
+++ b/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
@@ -610,7 +610,7 @@ public class SemanticVerifier implements UnitOLVisitor {
 		}
 
 		if( n.location() != null
-			&& !(n.location() instanceof ConstantStringExpression || n.location() instanceof VariablePathNode) ) {
+			&& !(n.location() instanceof ConstantStringExpression || n.location() instanceof VariableExpressionNode) ) {
 			error( n, "output port " + n.id() + "'s location is not a valid expression" );
 		}
 


### PR DESCRIPTION
A location described by a variable path in the source program is parsed as a `VariableExpressionNode` and not as a `VariablePathNode`.