### PR TITLE
CommMessage - moved above the use the ID_COUNTER definition and initi…

### DIFF
--- a/jolie/src/main/java/jolie/net/CommMessage.java
+++ b/jolie/src/main/java/jolie/net/CommMessage.java
@@ -55,10 +55,11 @@ public class CommMessage implements Serializable {
 	private static final AtomicLong REQUEST_ID_COUNTER = new AtomicLong( 1L );
 
 	public static final long GENERIC_REQUEST_ID = 0L;
-	public static final CommMessage UNDEFINED_MESSAGE =
-		new CommMessage( GENERIC_REQUEST_ID, "", Constants.ROOT_RESOURCE_PATH, Value.UNDEFINED_VALUE, null );
 
 	private static final AtomicLong ID_COUNTER = new AtomicLong( 1L );
+
+	public static final CommMessage UNDEFINED_MESSAGE =
+		new CommMessage( GENERIC_REQUEST_ID, "", Constants.ROOT_RESOURCE_PATH, Value.UNDEFINED_VALUE, null );
 
 	private final long requestId;
 	private final String operationName;


### PR DESCRIPTION
This modification try to solve the build problem raised during the dockerhub execution, because we tried to get a value from ID_COUNTER that wasn't initialized.

Look at the problem here
https://github.com/jolie/jolie/runs/5741696296?check_suite_focus=true 