### PR TITLE
startServiceSession - added missing operation start log in case execution = sequential

### DIFF
--- a/jolie/src/main/java/jolie/Interpreter.java
+++ b/jolie/src/main/java/jolie/Interpreter.java
@@ -1335,6 +1335,10 @@ public class Interpreter {
 			spawnedSession = new SessionThread(
 				sequence, state, initExecutionThread );
 			correlationEngine.onSessionStart( spawnedSession, starter, message );
+
+			logSessionStart( message.operationName(), spawnedSession.getSessionId(),
+				message.requestId(), message.value() );
+
 			spawnedSession.addSessionListener( correlationEngine );
 			spawnedSession.addSessionListener( new SessionListener() {
 				public void onSessionExecuted( SessionThread session ) {


### PR DESCRIPTION
In the above operation, the sequential case didn't log the operation start event.