### PR TITLE
Remove parentInterpreter as a dependency on embedding jolie service

### DIFF
--- a/jolie/src/main/java/jolie/Interpreter.java
+++ b/jolie/src/main/java/jolie/Interpreter.java
@@ -909,7 +909,7 @@ public class Interpreter {
 	}
 
 	/**
-	 * Constructor.
+	 * Constructor. for the JolieServiceNodeLoader
 	 *
 	 * @param programDirectory the program directory of this Interpreter, necessary if it is run inside
 	 *        a JAP file.
@@ -920,13 +920,12 @@ public class Interpreter {
 	 * @throws IOException if a Scanner constructor signals an error.
 	 */
 	public Interpreter( Configuration configuration,
-		File programDirectory, Interpreter parentInterpreter, Program internalServiceProgram,
+		File programDirectory, Map< URI, SymbolTable > parentSymbolTables, Program internalServiceProgram,
 		Value receivingEmbeddedValue )
 		throws FileNotFoundException, IOException {
 		this( configuration, programDirectory, Optional.of( receivingEmbeddedValue ) );
-
-		this.parentInterpreter = parentInterpreter;
 		this.internalServiceProgram = internalServiceProgram;
+		this.symbolTables.putAll( parentSymbolTables );
 	}
 
 	/**
@@ -1211,7 +1210,6 @@ public class Interpreter {
 				if( this.internalServiceProgram != null ) {
 					program = this.internalServiceProgram;
 					program = OLParseTreeOptimizer.optimize( program );
-					symbolTables.putAll( this.parentInterpreter.symbolTables );
 				} else {
 					ModuleParsingConfiguration configuration = new ModuleParsingConfiguration(
 						configuration().charset(),
@@ -1406,6 +1404,10 @@ public class Interpreter {
 			}
 		}
 		return factory;
+	}
+
+	public Map< URI, SymbolTable > symbolTables() {
+		return this.symbolTables;
 	}
 
 	public static class Configuration {

--- a/jolie/src/main/java/jolie/Interpreter.java
+++ b/jolie/src/main/java/jolie/Interpreter.java
@@ -913,7 +913,7 @@ public class Interpreter {
 	 *
 	 * @param programDirectory the program directory of this Interpreter, necessary if it is run inside
 	 *        a JAP file.
-	 * @param parentInterpreter
+	 * @param parentSymbolTables symbol table from the parent service
 	 * @param internalServiceProgram
 	 * @param receivingEmbeddedValue
 	 * @throws FileNotFoundException if one of the passed input files is not found.

--- a/jolie/src/main/java/jolie/runtime/embedding/JolieServiceNodeLoader.java
+++ b/jolie/src/main/java/jolie/runtime/embedding/JolieServiceNodeLoader.java
@@ -22,6 +22,7 @@ package jolie.runtime.embedding;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import jolie.Interpreter;
@@ -53,8 +54,8 @@ public class JolieServiceNodeLoader extends ServiceNodeLoader {
 
 			interpreter = new Interpreter(
 				configuration,
-				super.interpreter().programDirectory(),
-				super.interpreter(),
+				Paths.get( serviceNode().context().source() ).toFile(),
+				interpreter().symbolTables(),
 				builder.toProgram(),
 				v );
 


### PR DESCRIPTION
Fixes  https://github.com/kicito/jolie-packages-demo/tree/main/examples/name-clashing. By removing `parentInterpreter` from the constructor of the service node.

Note: `symbolTables` from the parent interpreter is still needed, since it is used for validating semantics of the program.