### PR TITLE
Add throws/catch exception on MalformURITemplate

### DIFF
--- a/extensions/http/src/main/java/jolie/net/HttpProtocol.java
+++ b/extensions/http/src/main/java/jolie/net/HttpProtocol.java
@@ -72,6 +72,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -755,9 +756,9 @@ public class HttpProtocol extends CommProtocol implements HttpUtils.HttpProtocol
 		}
 	}
 
-	private void send_appendParsedTemplate( String template, Value value, StringBuilder headerBuilder ) {
+	private void send_appendParsedTemplate( String template, Value value, StringBuilder headerBuilder )
+		throws MalformedURLException {
 		List< String > templateKeys = new ArrayList<>();
-		UriUtils uriUtils = new UriUtils();
 		Map< String, Object > params = new HashMap<>();
 
 		for( final Map.Entry< String, ValueVector > entry : value.children()
@@ -765,12 +766,12 @@ public class HttpProtocol extends CommProtocol implements HttpUtils.HttpProtocol
 			params.put( entry.getKey(), entry.getValue().first().valueObject() );
 		}
 
-		String uri = uriUtils.expand( template, params );
+		String uri = UriUtils.expand( template, params );
 
 		/* cleaning value from used keys */
 
 
-		uriUtils.match( template, uri ).children().forEach( ( s, values ) -> {
+		UriUtils.match( template, uri ).children().forEach( ( s, values ) -> {
 			templateKeys.add( s );
 		} );
 

--- a/javaServices/coreJavaServices/src/main/java/joliex/util/UriTemplates.java
+++ b/javaServices/coreJavaServices/src/main/java/joliex/util/UriTemplates.java
@@ -22,13 +22,15 @@
 package joliex.util;
 
 
+import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Map;
+
 import jolie.runtime.AndJarDeps;
+import jolie.runtime.FaultException;
 import jolie.runtime.JavaService;
 import jolie.runtime.Value;
 import jolie.runtime.ValueVector;
-
-import java.util.HashMap;
-import java.util.Map;
 
 
 @AndJarDeps( { "jolie-uri.jar", "handy-uri-templates.jar", "joda-time.jar" } )
@@ -38,7 +40,7 @@ public class UriTemplates extends JavaService {
 			request.getFirstChild( "uri" ).strValue() );
 	}
 
-	public String expand( Value request ) {
+	public String expand( Value request ) throws FaultException {
 		Map< String, Object > params = new HashMap<>();
 		if( request.hasChildren( "params" ) ) {
 			for( final Map.Entry< String, ValueVector > entry : request.getFirstChild( "params" ).children()
@@ -46,6 +48,10 @@ public class UriTemplates extends JavaService {
 				params.put( entry.getKey(), entry.getValue().first().valueObject() );
 			}
 		}
-		return jolie.uri.UriUtils.expand( request.getFirstChild( "template" ).strValue(), params );
+		try {
+			return jolie.uri.UriUtils.expand( request.getFirstChild( "template" ).strValue(), params );
+		} catch( MalformedURLException e ) {
+			throw new FaultException( "IOException", e );
+		}
 	}
 }

--- a/lib/jolie-uri/src/main/java/jolie/uri/UriUtils.java
+++ b/lib/jolie-uri/src/main/java/jolie/uri/UriUtils.java
@@ -19,9 +19,12 @@
 
 package jolie.uri;
 
+import com.damnhandy.uri.template.MalformedUriTemplateException;
 import com.damnhandy.uri.template.UriTemplate;
 import com.damnhandy.uri.template.UriTemplateMatcherFactory;
 import jolie.runtime.Value;
+
+import java.net.MalformedURLException;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -46,10 +49,14 @@ public class UriUtils {
 		return response;
 	}
 
-	public static String expand( String template, Map< String, Object > params ) {
-		UriTemplate t = UriTemplate.fromTemplate( template );
-		t.set( params );
-		return t.expand();
+	public static String expand( String template, Map< String, Object > params ) throws MalformedURLException {
+		try {
+			UriTemplate t = UriTemplate.fromTemplate( template );
+			t.set( params );
+			return t.expand();
+		} catch( MalformedUriTemplateException e ) {
+			throw new MalformedURLException( e.getMessage() );
+		}
 	}
 
 


### PR DESCRIPTION
Add `throws` and `catches` when `damnhandy.uri.template.UriTemplate` throws a `MalformedUriTemplateException`.