### PR TITLE
fix: side effect on handling querystrings

### DIFF
--- a/extensions/http/src/main/java/jolie/net/HttpProtocol.java
+++ b/extensions/http/src/main/java/jolie/net/HttpProtocol.java
@@ -751,7 +751,7 @@ public class HttpProtocol extends CommProtocol implements HttpUtils.HttpProtocol
 			if( qsFormat.equals( "json" ) ) {
 				send_appendJsonQueryString( message, headerBuilder );
 			} else {
-				send_appendQuerystring( message.value(), headerBuilder, message );
+				send_appendQuerystring( message.value().clone(), headerBuilder, message );
 			}
 		}
 	}


### PR DESCRIPTION
I don't think this is a efficient way to fix the issue. But currently there are side effect on appending querystring before sending an HTTP request. To be concrete, `send_appendQuerystring` has side-effect that it removes value of the sending message. Then the methods that execute later, such as header setter (snippet below), wouldn't received the proper value as intended.

https://github.com/jolie/jolie/blob/960417451299cfc6631a36272c8866df5163aad2/extensions/http/src/main/java/jolie/net/HttpProtocol.java#L886-L890