### PR TITLE
Check IndexOutOfBound when building error message

### DIFF
--- a/libjolie/src/main/java/jolie/lang/parse/AbstractParser.java
+++ b/libjolie/src/main/java/jolie/lang/parse/AbstractParser.java
@@ -700,7 +700,7 @@ public abstract class AbstractParser {
 			if( mesg.contains( "unexpected term found inside service" ) && token.content().isEmpty() ) {
 				// if the service does not have an ending curlybracket
 				extralines = getWholeScope( scopeName, scope );
-				int columnNumber = extralines.get( extralines.size() - 1 ).length() - 1;
+				int columnNumber = (!extralines.isEmpty()) ? extralines.get( extralines.size() - 1 ).length() - 1 : 0;
 				context =
 					new URIParsingContext( context.source(), context.startLine(), context.endLine(), columnNumber,
 						columnNumber, extralines );


### PR DESCRIPTION
Running the following snippet
```
service main {
    main {
        nullProcess
}
```
prints `Index -1 out of bounds for length 0` on the terminal.

Note: there might be a case that is left unchecked. I haven't revised the whole file.