### PR TITLE
Fix transfer-encoding: chunked returns empty result

### DIFF
--- a/extensions/http/src/main/java/jolie/net/http/HttpParser.java
+++ b/extensions/http/src/main/java/jolie/net/http/HttpParser.java
@@ -261,7 +261,7 @@ public class HttpParser {
 
 		String p = message.getProperty( "transfer-encoding" );
 
-		if( p != null && p.startsWith( "chunked" ) ) {
+		if( p != null && p.trim().startsWith( "chunked" ) ) {
 			// Transfer-encoding has the precedence over Content-Length
 			chunked = true;
 		} else {


### PR DESCRIPTION
This PR fixes the issue when an HTTP server responds with the header `transfer-encoding: chunked`, Jolie will ignore the entire field (since ` chucked` != `chunked`) and will not be able to parse the response.