### PR TITLE
Ensure all dependencies are added to the Symboltables

### DIFF
--- a/libjolie/src/main/java/jolie/lang/parse/module/ModuleCrawler.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/ModuleCrawler.java
@@ -145,7 +145,17 @@ class ModuleCrawler {
 			}
 
 			if( ModuleCrawler.inCache( module.uri() ) ) {
-				result.addModuleRecord( ModuleCrawler.getRecordFromCache( module.uri() ) );
+				ModuleRecord cached = ModuleCrawler.getRecordFromCache( module.uri() );
+				for( ImportedSymbolInfo importedSymbol : cached.symbolTable().importedSymbolInfos() ) {
+					if( importedSymbol.moduleSource().isPresent() ) {
+						dependencies.add( importedSymbol.moduleSource().get() );
+					} else {
+						ModuleRecord record = new ModuleParser( parserConfiguration ).parse( module );
+						result.addModuleRecord( record );
+						dependencies.addAll( crawlModule( record ) );
+					}
+				}
+				result.addModuleRecord( cached );
 			} else {
 				ModuleRecord record = new ModuleParser( parserConfiguration ).parse( module );
 				result.addModuleRecord( record );


### PR DESCRIPTION
This PR fixes the issue when calling `loadEmbeddedService@runtime`, if the targeting service(A) has a dependency(B) that is not included in the parent interpreter SymbolTable. The crawler will not add (B) to the SymbolTable. And resulted in the resolver will not be able to locate (B) and crashing the program.