### PR TITLE
fix in/decrement process and add type precedence on evaluating equal …

### DIFF
--- a/jolie/src/main/java/jolie/process/PostDecrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PostDecrementProcess.java
@@ -22,6 +22,8 @@
 package jolie.process;
 
 import jolie.ExecutionThread;
+import jolie.lang.Constants;
+import jolie.runtime.FaultException;
 import jolie.runtime.Value;
 import jolie.runtime.VariablePath;
 import jolie.runtime.expression.Expression;
@@ -41,17 +43,42 @@ public class PostDecrementProcess implements Process, Expression {
 		return new PostDecrementProcess( (VariablePath) path.cloneExpression( reason ) );
 	}
 
-	public void run() {
+	public void run() throws FaultException {
 		if( ExecutionThread.currentThread().isKilled() )
 			return;
 		Value val = path.getValue();
-		val.setValue( val.intValue() - 1 );
+
+		if( !val.isDefined() ) {
+			val.setValue( 1 );
+		} else {
+			final Object o = val.valueObject();
+			if( o instanceof Integer ) {
+				val.setValue( ((Integer) o).intValue() - 1 );
+			} else if( o instanceof Double ) {
+				val.setValue( ((Double) o).doubleValue() - 1 );
+			} else if( o instanceof Long ) {
+				val.setValue( ((Long) o).longValue() - 1 );
+			} else {
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." );
+			}
+		}
 	}
 
-	public Value evaluate() {
+	public Value evaluate() throws FaultException.RuntimeFaultException {
 		Value val = path.getValue();
 		Value orig = Value.create( val.intValue() );
 		val.setValue( val.intValue() - 1 );
+		final Object o = val.valueObject();
+		if( o instanceof Integer ) {
+			val.setValue( ((Integer) o).intValue() - 1 );
+		} else if( o instanceof Double ) {
+			val.setValue( ((Double) o).doubleValue() - 1 );
+		} else if( o instanceof Long ) {
+			val.setValue( ((Long) o).longValue() - 1 );
+		} else {
+			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
+				.toRuntimeFaultException();
+		}
 		return orig;
 	}
 

--- a/jolie/src/main/java/jolie/process/PreDecrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PreDecrementProcess.java
@@ -22,6 +22,8 @@
 package jolie.process;
 
 import jolie.ExecutionThread;
+import jolie.lang.Constants;
+import jolie.runtime.FaultException;
 import jolie.runtime.Value;
 import jolie.runtime.VariablePath;
 import jolie.runtime.expression.Expression;
@@ -41,16 +43,45 @@ public class PreDecrementProcess implements Process, Expression {
 		return new PreDecrementProcess( (VariablePath) path.cloneExpression( reason ) );
 	}
 
-	public void run() {
+	@Override
+	public void run() throws FaultException {
 		if( ExecutionThread.currentThread().isKilled() )
 			return;
 		Value val = path.getValue();
-		val.setValue( val.intValue() - 1 );
+
+		if( !val.isDefined() ) {
+			val.setValue( 1 );
+		} else {
+			final Object o = val.valueObject();
+			if( o instanceof Integer ) {
+				val.setValue( ((Integer) o).intValue() - 1 );
+			} else if( o instanceof Double ) {
+				val.setValue( ((Double) o).doubleValue() - 1 );
+			} else if( o instanceof Long ) {
+				val.setValue( ((Long) o).longValue() - 1 );
+			} else {
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." );
+			}
+		}
 	}
 
 	public Value evaluate() {
 		Value val = path.getValue();
-		val.setValue( val.intValue() - 1 );
+		if( !val.isDefined() ) {
+			val.setValue( -1 );
+		} else {
+			final Object o = val.valueObject();
+			if( o instanceof Integer ) {
+				val.setValue( ((Integer) o).intValue() - 1 );
+			} else if( o instanceof Double ) {
+				val.setValue( ((Double) o).doubleValue() - 1 );
+			} else if( o instanceof Long ) {
+				val.setValue( ((Long) o).longValue() - 1 );
+			} else {
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
+					.toRuntimeFaultException();
+			}
+		}
 		return val;
 	}
 

--- a/jolie/src/main/java/jolie/process/PreIncrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PreIncrementProcess.java
@@ -20,6 +20,8 @@
 package jolie.process;
 
 import jolie.ExecutionThread;
+import jolie.lang.Constants;
+import jolie.runtime.FaultException;
 import jolie.runtime.Value;
 import jolie.runtime.VariablePath;
 import jolie.runtime.expression.Expression;
@@ -42,17 +44,45 @@ public class PreIncrementProcess implements Process, Expression {
 	}
 
 	@Override
-	public void run() {
+	public void run() throws FaultException {
 		if( ExecutionThread.currentThread().isKilled() )
 			return;
 		final Value val = path.getValue();
-		val.setValue( val.intValue() + 1 );
+
+		if( !val.isDefined() ) {
+			val.setValue( 1 );
+		} else {
+			final Object o = val.valueObject();
+			if( o instanceof Integer ) {
+				val.setValue( ((Integer) o).intValue() + 1 );
+			} else if( o instanceof Double ) {
+				val.setValue( ((Double) o).doubleValue() + 1 );
+			} else if( o instanceof Long ) {
+				val.setValue( ((Long) o).longValue() + 1 );
+			} else {
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." );
+			}
+		}
 	}
 
 	@Override
 	public Value evaluate() {
 		final Value val = path.getValue();
-		val.setValue( val.intValue() + 1 );
+		if( !val.isDefined() ) {
+			val.setValue( 1 );
+		} else {
+			final Object o = val.valueObject();
+			if( o instanceof Integer ) {
+				val.setValue( ((Integer) o).intValue() + 1 );
+			} else if( o instanceof Double ) {
+				val.setValue( ((Double) o).doubleValue() + 1 );
+			} else if( o instanceof Long ) {
+				val.setValue( ((Long) o).longValue() + 1 );
+			} else {
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
+					.toRuntimeFaultException();
+			}
+		}
 		return val;
 	}
 

--- a/jolie/src/main/java/jolie/runtime/CompareOperators.java
+++ b/jolie/src/main/java/jolie/runtime/CompareOperators.java
@@ -29,15 +29,16 @@ import java.util.function.BiPredicate;
  * @author Fabrizio Montesi
  */
 public final class CompareOperators {
+
 	public final static BiPredicate< Value, Value > EQUAL =
 		( left, right ) -> left.isEqualTo( right );
 	public final static BiPredicate< Value, Value > NOT_EQUAL = EQUAL.negate();
 	public final static BiPredicate< Value, Value > MINOR =
 		( left, right ) -> {
-			if( left.isDouble() ) {
+			if( left.isDouble() || right.isDouble() ) {
 				return (left.doubleValue() < right.doubleValue());
 			}
-			if( left.isLong() ) {
+			if( left.isLong() || right.isLong() ) {
 				return (left.longValue() < right.longValue());
 			} else {
 				return (left.intValue() < right.intValue());
@@ -45,10 +46,10 @@ public final class CompareOperators {
 		};
 	public final static BiPredicate< Value, Value > MAJOR =
 		( left, right ) -> {
-			if( left.isDouble() ) {
+			if( left.isDouble() || right.isDouble() ) {
 				return (left.doubleValue() > right.doubleValue());
 			}
-			if( left.isLong() ) {
+			if( left.isLong() || right.isLong() ) {
 				return (left.longValue() > right.longValue());
 			} else {
 				return (left.intValue() > right.intValue());
@@ -56,10 +57,10 @@ public final class CompareOperators {
 		};
 	public final static BiPredicate< Value, Value > MINOR_OR_EQUAL =
 		( left, right ) -> {
-			if( left.isDouble() ) {
+			if( left.isDouble() || right.isDouble() ) {
 				return (left.doubleValue() <= right.doubleValue());
 			}
-			if( left.isLong() ) {
+			if( left.isLong() || right.isLong() ) {
 				return (left.longValue() <= right.longValue());
 			} else {
 				return (left.intValue() <= right.intValue());
@@ -67,10 +68,10 @@ public final class CompareOperators {
 		};
 	public final static BiPredicate< Value, Value > MAJOR_OR_EQUAL =
 		( left, right ) -> {
-			if( left.isDouble() ) {
+			if( left.isDouble() || right.isDouble() ) {
 				return (left.doubleValue() >= right.doubleValue());
 			}
-			if( left.isLong() ) {
+			if( left.isLong() || right.isLong() ) {
 				return (left.longValue() >= right.longValue());
 			} else {
 				return (left.intValue() >= right.intValue());

--- a/jolie/src/main/java/jolie/runtime/Value.java
+++ b/jolie/src/main/java/jolie/runtime/Value.java
@@ -552,18 +552,18 @@ public abstract class Value implements Expression, Cloneable {
 	public final synchronized boolean equals( Value val ) {
 		boolean r = false;
 		if( val.isDefined() ) {
-			if( isByteArray() ) {
+			if( isByteArray() || val.isByteArray() ) {
 				r = byteArrayValue().equals( val.byteArrayValue() );
-			} else if( isString() ) {
+			} else if( isString() || val.isString() ) {
 				r = strValue().equals( val.strValue() );
-			} else if( isInt() ) {
-				r = intValue() == val.intValue();
-			} else if( isDouble() ) {
+			} else if( isDouble() || val.isDouble() ) {
 				r = doubleValue() == val.doubleValue();
-			} else if( isBool() ) {
-				r = boolValue() == val.boolValue();
-			} else if( isLong() ) {
+			} else if( isLong() || val.isLong() ) {
 				r = longValue() == val.longValue();
+			} else if( isInt() || val.isInt() ) {
+				r = intValue() == val.intValue();
+			} else if( isBool() || val.isBool() ) {
+				r = boolValue() == val.boolValue();
 			} else if( valueObject() != null ) {
 				r = valueObject().equals( val.valueObject() );
 			}

--- a/libjolie/src/main/java/jolie/lang/parse/OLParser.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParser.java
@@ -3384,11 +3384,23 @@ public class OLParser extends AbstractParser {
 				nextToken();
 				break;
 			case INT:
-				retVal = new ConstantIntegerExpression( getContext(), Integer.parseInt( token.content() ) );
+				int intVal = 0;
+				try {
+					intVal = Integer.parseInt( token.content() );
+				} catch( NumberFormatException e ) {
+					throwException( e.getMessage() );
+				}
+				retVal = new ConstantIntegerExpression( getContext(), intVal );
 				nextToken();
 				break;
 			case LONG:
-				retVal = new ConstantLongExpression( getContext(), Long.parseLong( token.content() ) );
+				long longVal = 0;
+				try {
+					longVal = Long.parseLong( token.content() );
+				} catch( NumberFormatException e ) {
+					throwException( e.getMessage() );
+				}
+				retVal = new ConstantLongExpression( getContext(), longVal );
 				nextToken();
 				break;
 			case TRUE:
@@ -3400,7 +3412,13 @@ public class OLParser extends AbstractParser {
 				nextToken();
 				break;
 			case DOUBLE:
-				retVal = new ConstantDoubleExpression( getContext(), Double.parseDouble( token.content() ) );
+				double doubleVal = 0;
+				try {
+					doubleVal = Double.parseDouble( token.content() );
+				} catch( NumberFormatException e ) {
+					throwException( e.getMessage() );
+				}
+				retVal = new ConstantDoubleExpression( getContext(), doubleVal );
 				nextToken();
 				break;
 			case LPAREN:

--- a/test/primitives/comparisons.ol
+++ b/test/primitives/comparisons.ol
@@ -51,7 +51,7 @@ define doTest
 		throw( TestFailed, "int: conversion problems" )
 	};
 	if ( x != bool(1) || x != long(1) || x != double(1) || x != string(1) ) {
-		throw( TestFailed, "int: conversion problems" )
+		throw( TestFailed, "int: conversion problems with cast" )
 	};
 
 	x = 1L;
@@ -75,11 +75,11 @@ define doTest
 	if ( 1.0 != 1.0 || x != x || x != double(x) ) {
 		throw( TestFailed, "double: values do not match" )
 	};
-	if ( x != true || x != 1 || x != 1L || x != "1" ) {
-		throw( TestFailed, "int: conversion problems" )
+	if ( x != true || x != 1 || x != 1L || x != "1.0" ) {
+		throw( TestFailed, "double: conversion problems" )
 	};
 	if ( x != bool(1.0) || x != int(1.0) || x != long(1.0) || x != string(1.0) ) {
-		throw( TestFailed, "int: conversion problems" )
+		throw( TestFailed, "double: conversion problems with cast" )
 	};
 
 	x = "Döner";
@@ -111,6 +111,29 @@ define doTest
 	};
 	if ( a.a == b.a ) {
 		throw( TestFailed, "compound: child values do match" )
+	}
+
+
+	
+	if ( 777640662 == 1662929984216L ) {
+		throw( TestFailed, "expected 777640662 != 1662929984216L, but it is evaluated to true " + a )
+	}
+	
+	if ( 1662929984216L == 777640662 ) {
+		throw( TestFailed, "expected 1662929984216L != 777640662, but it is evaluated to true " + a )
+	}
+
+	if ( 0.0 == 9223372032559808512L  ) { // 111111111111111111111111111111100000000000000000000000000000000_2
+		throw( TestFailed, "expected 9223372032559808512L be inequal to 0.0, but it is evaluated to false " + a )
+	}
+
+	if ( 9223372032559808512L == 0.0  ) { // 111111111111111111111111111111100000000000000000000000000000000_2
+		throw( TestFailed, "expected 9223372032559808512L be inequal to 0.0, but it is evaluated to false " + a )
+	}
+
+	// (2^31) - 1 int vs double
+	if ( 2147483647 != 2147483647.0  ) {
+		throw( TestFailed, "expected 2147483647 be equal to 2147483647.0, but it is evaluated to false " + a )
 	}
 }
 

--- a/test/primitives/expressions.ol
+++ b/test/primitives/expressions.ol
@@ -242,7 +242,7 @@ define testTypeImplicitConversion{
 	testAIsInt
 }
 
-define doTest
+define testArithmeticOperators
 {
 	if ( "Hello, " + "World!" != "Hello, World!" ) {
 		throw( TestFailed, "string concatenation does not match correct result" )
@@ -259,6 +259,18 @@ define doTest
 		throw( TestFailed, "compact inline arithmetic operators do not work correctly" )
 	};
 
+
+	// issue 432
+	a = 1662929984215L
+	a++
+	if ( a != 1662929984216L ) {
+		throw( TestFailed, "expected a to be 1662929984216, received a = " + a )
+	}
+}
+
+define doTest
+{
+	testArithmeticOperators;
 	testBooleans;
 	testCasts;
 	testTypeImplicitConversion


### PR DESCRIPTION
This PR fixes #432.  Also, we discover another related bug where Jolie always cast the value's type based on the left expression. Which breaks the symmetric property of equality as the code snippet below shows.  This PR fixes it as well :)

```
	if ( 777640662 == 1662929984216L ) { // cast both to int, do not throws
		throw( TestFailed, "expected 777640662 != 1662929984216L, but it is evaluated to true " + a )
	}
	
	if ( 1662929984216L == 777640662 ) {// cast both to long, throws
		throw( TestFailed, "expected 1662929984216L != 777640662, but it is evaluated to true " + a )
	}
```