### PR TITLE
fix null empty message content

### DIFF
--- a/extensions/http/src/main/java/jolie/net/http/HttpParser.java
+++ b/extensions/http/src/main/java/jolie/net/http/HttpParser.java
@@ -348,6 +348,8 @@ public class HttpParser {
 			}
 
 			message.setContent( buffer );
+		} else {
+			message.setContent( new byte[ 0 ] );
 		}
 	}
 

--- a/extensions/jsonrpc/src/main/java/jolie/net/LSPParser.java
+++ b/extensions/jsonrpc/src/main/java/jolie/net/LSPParser.java
@@ -136,6 +136,8 @@ public class LSPParser {
 
 		if( buffer != null ) {
 			message.setContent( buffer );
+		} else {
+			message.setContent( new byte[ 0 ] );
 		}
 	}
 


### PR DESCRIPTION
This PR fixes an issue where HTTPMessage.content is null when the request is empty.