### PR TITLE
ParsingUtils to use local cache

### DIFF
--- a/jolie/src/main/java/jolie/Interpreter.java
+++ b/jolie/src/main/java/jolie/Interpreter.java
@@ -1177,7 +1177,8 @@ public class Interpreter {
 						configuration().packagePaths(),
 						configuration().jolieClassLoader(),
 						configuration().constants(),
-						false );
+						false,
+						true );
 					Modules.ModuleParsedResult parsedResult =
 						Modules.parseModule( configuration, configuration().inputStream(),
 							configuration().programFilepath().toURI() );

--- a/libjolie/src/main/java/jolie/lang/parse/module/ModuleCrawler.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/ModuleCrawler.java
@@ -74,10 +74,16 @@ class ModuleCrawler {
 
 	private final ModuleFinder finder;
 	private final ModuleParsingConfiguration parserConfiguration;
+	private final ModuleRecordCache cache;
 
 	private ModuleCrawler( ModuleParsingConfiguration parserConfiguration, ModuleFinder finder ) {
 		this.finder = finder;
 		this.parserConfiguration = parserConfiguration;
+		if( parserConfiguration.useGlobalCache() ) {
+			this.cache = Modules.CACHE;
+		} else {
+			this.cache = new ModuleRecordCache();
+		}
 	}
 
 	private ModuleSource findModule( ImportPath importPath, URI source )
@@ -108,7 +114,7 @@ class ModuleCrawler {
 				throw new ModuleException( message );
 			}
 		}
-		ModuleRecordCache.put( record, modulesToCrawl
+		cache.put( record, modulesToCrawl
 			.stream()
 			.map( ModuleSource::uri )
 			.collect( Collectors.toList() ) );
@@ -131,8 +137,8 @@ class ModuleCrawler {
 				continue;
 			}
 
-			if( ModuleRecordCache.contains( module.uri() ) ) {
-				ModuleRecord cached = ModuleRecordCache.get( module.uri() );
+			if( cache.contains( module.uri() ) ) {
+				ModuleRecord cached = cache.get( module.uri() );
 				for( ImportedSymbolInfo importedSymbol : cached.symbolTable().importedSymbolInfos() ) {
 					if( importedSymbol.moduleSource().isPresent() ) {
 						dependencies.add( importedSymbol.moduleSource().get() );

--- a/libjolie/src/main/java/jolie/lang/parse/module/ModuleParsingConfiguration.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/ModuleParsingConfiguration.java
@@ -18,16 +18,19 @@ public class ModuleParsingConfiguration {
 
 	private final Map< String, Scanner.Token > constantsMap;
 
+	private final boolean useGlobalCache;
+
 
 	public ModuleParsingConfiguration( String charset, String[] includePaths, String[] packagePaths,
 		ClassLoader classLoader,
-		Map< String, Scanner.Token > constantsMap, boolean includeDocumentation ) {
+		Map< String, Scanner.Token > constantsMap, boolean includeDocumentation, boolean useGlobalCache ) {
 		this.charset = charset;
 		this.includePaths = includePaths;
 		this.packagePaths = packagePaths;
 		this.classLoader = classLoader;
 		this.constantsMap = constantsMap;
 		this.includeDocumentation = includeDocumentation;
+		this.useGlobalCache = useGlobalCache;
 	}
 
 	public String[] includePaths() {
@@ -48,6 +51,10 @@ public class ModuleParsingConfiguration {
 
 	public boolean includeDocumentation() {
 		return includeDocumentation;
+	}
+
+	public boolean useGlobalCache() {
+		return useGlobalCache;
 	}
 
 	public Map< String, Scanner.Token > constantsMap() {

--- a/libjolie/src/main/java/jolie/lang/parse/util/ParsingUtils.java
+++ b/libjolie/src/main/java/jolie/lang/parse/util/ParsingUtils.java
@@ -65,7 +65,8 @@ public class ParsingUtils {
 			packagePaths,
 			classLoader,
 			definedConstants,
-			includeDocumentation );
+			includeDocumentation,
+			false );
 
 		ModuleParsedResult parseResult = Modules.parseModule( configuration, inputStream, source );
 
@@ -134,7 +135,7 @@ public class ParsingUtils {
 			packagePaths,
 			classLoader,
 			definedConstants,
-			includeDocumentation );
+			includeDocumentation, false );
 
 		ModuleParsedResult parseResult = Modules.parseModule( configuration, inputStream, source );
 		SemanticVerifier semanticVerifier = new SemanticVerifier( parseResult.mainProgram(),


### PR DESCRIPTION
In order to reduce the memory footprint when Parsing the code, this PR implements an ability to choose whether to keep the parsing result on the memory or to discard it after parsing the code.

All static embedding will save the result on the cache, while the dynamic parsing (@RuntimeService) will discard the result after finished.