### PR TITLE
Fix Cleaner deamon thread is not closing after the service termination

### DIFF
--- a/extensions/btl2cap/src/main/java/jolie/net/BTL2CapListener.java
+++ b/extensions/btl2cap/src/main/java/jolie/net/BTL2CapListener.java
@@ -73,12 +73,10 @@ public class BTL2CapListener extends CommListener {
 	}
 
 	@Override
-	public void shutdown() {
+	public void onShutdown() {
 		try {
 			connectionNotifier.close();
 		} catch( IOException e ) {
 		}
-		super.clearInterpreter();
-		super.inputPort().clearLocationValue();
 	}
 }

--- a/extensions/btl2cap/src/main/java/jolie/net/BTL2CapListener.java
+++ b/extensions/btl2cap/src/main/java/jolie/net/BTL2CapListener.java
@@ -78,5 +78,7 @@ public class BTL2CapListener extends CommListener {
 			connectionNotifier.close();
 		} catch( IOException e ) {
 		}
+		super.clearInterpreter();
+		super.inputPort().clearLocationValue();
 	}
 }

--- a/extensions/localsocket/src/main/java/jolie/net/LocalSocketListener.java
+++ b/extensions/localsocket/src/main/java/jolie/net/LocalSocketListener.java
@@ -58,6 +58,8 @@ public class LocalSocketListener extends CommListener {
 		if( !socketAddress.isAbstract() ) {
 			new File( socketAddress.getPath() ).delete();
 		}
+		super.clearInterpreter();
+		super.inputPort().clearLocationValue();
 	}
 
 	@Override

--- a/extensions/localsocket/src/main/java/jolie/net/LocalSocketListener.java
+++ b/extensions/localsocket/src/main/java/jolie/net/LocalSocketListener.java
@@ -54,12 +54,10 @@ public class LocalSocketListener extends CommListener {
 	}
 
 	@Override
-	public void shutdown() {
+	public void onShutdown() {
 		if( !socketAddress.isAbstract() ) {
 			new File( socketAddress.getPath() ).delete();
 		}
-		super.clearInterpreter();
-		super.inputPort().clearLocationValue();
 	}
 
 	@Override

--- a/extensions/rmi/src/main/java/joliex/rmi/RMIListener.java
+++ b/extensions/rmi/src/main/java/joliex/rmi/RMIListener.java
@@ -68,7 +68,7 @@ public class RMIListener extends CommListener {
 	}
 
 	@Override
-	public void shutdown() {
+	public void onShutdown() {
 		try {
 			registry.unbind( entryName );
 		} catch( RemoteException | NotBoundException e ) {

--- a/jolie/src/main/java/jolie/NativeJolieThread.java
+++ b/jolie/src/main/java/jolie/NativeJolieThread.java
@@ -21,15 +21,17 @@
 
 package jolie;
 
+import java.lang.ref.WeakReference;
+
 public class NativeJolieThread extends Thread implements InterpreterThread {
-	private final Interpreter interpreter;
+	private final WeakReference< Interpreter > interpreter;
 
 	/**
 	 * Constructor
 	 */
 	public NativeJolieThread( Interpreter interpreter, ThreadGroup group, String name ) {
 		super( group, interpreter.programFilename() + "-" + name );
-		this.interpreter = interpreter;
+		this.interpreter = new WeakReference<>( interpreter );
 	}
 
 	/**
@@ -41,7 +43,7 @@ public class NativeJolieThread extends Thread implements InterpreterThread {
 	 */
 	public NativeJolieThread( Interpreter interpreter, String name ) {
 		super( interpreter.programFilename() + "-" + name );
-		this.interpreter = interpreter;
+		this.interpreter = new WeakReference<>( interpreter );
 	}
 
 	/**
@@ -59,13 +61,22 @@ public class NativeJolieThread extends Thread implements InterpreterThread {
 	 */
 	public NativeJolieThread( Interpreter interpreter, Runnable r ) {
 		super( r, interpreter.programFilename() + "-" + JolieThread.createThreadName() );
-		this.interpreter = interpreter;
+		this.interpreter = new WeakReference<>( interpreter );
 	}
 
 	/**
 	 * Returns the interpreter that this thread refers to.
 	 */
 	public Interpreter interpreter() {
-		return interpreter;
+		return interpreter.get();
+	}
+
+	/**
+	 * Clear interpreter reference
+	 */
+	public void clearInterpreter() {
+		if( !interpreter.isEnqueued() ) {
+			interpreter.clear();
+		}
 	}
 }

--- a/jolie/src/main/java/jolie/net/CommListener.java
+++ b/jolie/src/main/java/jolie/net/CommListener.java
@@ -80,10 +80,19 @@ public abstract class CommListener extends NativeJolieThread {
 	}
 
 	/**
-	 * Requests the shutdown of this listener, so that it receives no more messages.
+	 * Specific shutdown behavior for each implementation.
 	 *
 	 * The behaviour of this method depends on the implementation: there is no guarantee that the
 	 * shutdown has been completed on return of this method, only that it has been requested.
 	 */
-	abstract public void shutdown();
+	abstract public void onShutdown();
+
+	/**
+	 * Requests the shutdown of this listener, so that it receives no more messages.
+	 */
+	public void shutdown() {
+		this.onShutdown();
+		this.inputPort().clearLocationValue();
+		super.clearInterpreter();
+	}
 }

--- a/jolie/src/main/java/jolie/net/LocalListener.java
+++ b/jolie/src/main/java/jolie/net/LocalListener.java
@@ -82,10 +82,7 @@ public class LocalListener extends CommListener {
 	}
 
 	@Override
-	public void shutdown() {
-		super.clearInterpreter();
-		super.inputPort().clearLocationValue();
-	}
+	public void onShutdown() {}
 
 	@Override
 	public void run() {}

--- a/jolie/src/main/java/jolie/net/LocalListener.java
+++ b/jolie/src/main/java/jolie/net/LocalListener.java
@@ -82,7 +82,10 @@ public class LocalListener extends CommListener {
 	}
 
 	@Override
-	public void shutdown() {}
+	public void shutdown() {
+		super.clearInterpreter();
+		super.inputPort().clearLocationValue();
+	}
 
 	@Override
 	public void run() {}

--- a/jolie/src/main/java/jolie/net/SocketListener.java
+++ b/jolie/src/main/java/jolie/net/SocketListener.java
@@ -64,15 +64,13 @@ public class SocketListener extends CommListener {
 	}
 
 	@Override
-	public void shutdown() {
+	public void onShutdown() {
 		if( serverChannel.isOpen() ) {
 			try {
 				serverChannel.close();
 			} catch( IOException e ) {
 			}
 		}
-		super.clearInterpreter();
-		super.inputPort().clearLocationValue();
 	}
 
 	@Override

--- a/jolie/src/main/java/jolie/net/SocketListener.java
+++ b/jolie/src/main/java/jolie/net/SocketListener.java
@@ -71,6 +71,8 @@ public class SocketListener extends CommListener {
 			} catch( IOException e ) {
 			}
 		}
+		super.clearInterpreter();
+		super.inputPort().clearLocationValue();
 	}
 
 	@Override

--- a/jolie/src/main/java/jolie/net/ports/InputPort.java
+++ b/jolie/src/main/java/jolie/net/ports/InputPort.java
@@ -181,4 +181,8 @@ public class InputPort implements Port {
 
 		return ret;
 	}
+
+	public void clearLocationValue() {
+		this.locationVariablePath.getValue().erase();
+	}
 }


### PR DESCRIPTION
Due to the reference from Listeners that keeps the interpreter object in the memory Cleaner daemon thread never terminates and stays alive throughout the whole execution. This PR clears the interpreter object and erases the state location value on the listener shutdown. It also uses WeakReference for the interpreter to help the gc clean the reference.