### PR TITLE
add missing RequestReponse

### DIFF
--- a/packages/scheduler.ol
+++ b/packages/scheduler.ol
@@ -48,6 +48,7 @@ type SetCronJobRequest: void {
 }
 
 interface SchedulerInterface{
+   RequestResponse:
    // Delete an existing cron job
    deleteCronJob( DeleteCronJobRequest )( void ),
 


### PR DESCRIPTION
Importing the `scheduler` module using the new syntax is currently broken. This patch addresses the syntactic error I was getting.