### PR TITLE
refactor launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,23 +15,21 @@
 				"${workspaceFolder}/include",
 				"-p",
 				"${workspaceFolder}/packages",
+				"${input:trace}",
 				"${input:programName}"
-			]
-		},
-		{
-			"type": "java",
-			"name": "Windows: Debug Jolie (with input program)",
-			"request": "launch",
-			"mainClass": "jolie.Jolie",
-			"projectName": "jolie-cli",
-			"cwd": "${workspaceFolder}\\test",
-			"args": [
-				"-l",
-				".\\lib\\*;${workspaceFolder}\\dist\\jolie\\lib;${workspaceFolder}\\dist\\jolie\\javaServices\\*;${workspaceFolder}\\dist\\jolie\\extensions/*",
-				"-i",
-				"${workspaceFolder}\\include",
-				"${input:programName}"
+			],
+			"windows": {
+				"args": [
+					"-l",
+					".\\lib\\*;${workspaceFolder}\\dist\\jolie\\lib;${workspaceFolder}\\dist\\jolie\\javaServices\\*;${workspaceFolder}\\dist\\jolie\\extensions/*",
+					"-i",
+					"${workspaceFolder}\\include",
+					"-p",
+					"${workspaceFolder}\\packages",
+					"${input:trace}",
+					"${input:programName}"
 				]
+			}
 		},
 		{
 			"type": "java",
@@ -48,7 +46,18 @@
 				"-p",
 				"${workspaceFolder}/packages",
 				"test.ol"
-			]
+			],
+			"windows": {
+				"args": [
+					"-l",
+					".\\lib\\*;${workspaceFolder}\\dist\\jolie\\lib;${workspaceFolder}\\dist\\jolie\\javaServices\\*;${workspaceFolder}\\dist\\jolie\\extensions/*",
+					"-i",
+					"${workspaceFolder}\\include",
+					"-p",
+					"${workspaceFolder}\\packages",
+					"test.ol"
+				]
+			}
 		},
 		{
 			"type": "java",
@@ -64,59 +73,54 @@
 				"${workspaceFolder}/include",
 				"-p",
 				"${workspaceFolder}/packages",
+				"${input:trace}",
 				"test.ol",
 				"${input:testName}"
-			]
+			],
+			"windows": {
+				"args": [
+					"-l",
+					".\\lib\\*;${workspaceFolder}\\dist\\jolie\\lib;${workspaceFolder}\\dist\\jolie\\javaServices\\*;${workspaceFolder}\\dist\\jolie\\extensions/*",
+					"-i",
+					"${workspaceFolder}\\include",
+					"-p",
+					"${workspaceFolder}\\packages",
+					"${input:trace}",
+					"test.ol",
+					"${input:programName}"
+				]
+			}
 		},
 		{
 			"type": "java",
 			"name": "Tests - HTTP GET",
 			"request": "launch",
 			"mainClass": "jolie.Jolie",
-			"projectName": "jolie",
+			"projectName": "jolie-cli",
 			"cwd": "${workspaceFolder}/test",
 			"args": [
 				"-l",
 				"./lib/*:${workspaceFolder}/dist/jolie/lib:${workspaceFolder}/dist/jolie/javaServices/*:${workspaceFolder}/dist/jolie/extensions/*",
 				"-i",
 				"${workspaceFolder}/include",
-				"test.ol",
-				".*http_get.*"
-			]
-		},
-		{
-			"type": "java",
-			"name": "Windows: Tests - Custom Test",
-			"request": "launch",
-			"mainClass": "jolie.Jolie",
-			"projectName": "jolie-cli",
-			"cwd": "${workspaceFolder}\\test",
-			"args": [
-				"-l",
-				".\\lib\\*;${workspaceFolder}\\dist\\jolie\\lib;${workspaceFolder}\\dist\\jolie\\javaServices\\*;${workspaceFolder}\\dist\\jolie\\extensions\\*",
-				"-i",
-				"${workspaceFolder}\\include",
 				"-p",
 				"${workspaceFolder}\\packages",
 				"test.ol",
-				"${input:programName}"
-			]
-		},
-		{
-			"type": "java",
-			"name": "Tests - HTTP GET (Windows)",
-			"request": "launch",
-			"mainClass": "jolie.Jolie",
-			"projectName": "jolie",
-			"cwd": "${workspaceFolder}/test",
-			"args": [
-				"-l",
-				".\\lib\\*;${workspaceFolder}\\dist\\jolie\\lib;${workspaceFolder}\\dist\\jolie\\javaServices/*;${workspaceFolder}\\dist\\jolie\\extensions\\*",
-				"-i",
-				"${workspaceFolder}\\include",
-				"test.ol",
 				".*http_get.*"
-			]
+			],
+			"windows": {
+				"args": [
+					"-l",
+					".\\lib\\*;${workspaceFolder}\\dist\\jolie\\lib;${workspaceFolder}\\dist\\jolie\\javaServices\\*;${workspaceFolder}\\dist\\jolie\\extensions/*",
+					"-i",
+					"${workspaceFolder}\\include",
+					"-p",
+					"${workspaceFolder}\\packages",
+					"${input:trace}",
+					"test.ol",
+					".*http_get.*"
+				]
+			}
 		},
 	],
 	"inputs": [
@@ -129,6 +133,16 @@
 			"id": "testName",
 			"type": "promptString",
 			"description": "The name of the test to be launched"
+		},
+		{
+			"type": "pickString",
+			"id": "trace",
+			"description": "Run with --trace?",
+			"options": [
+				"",
+				"--trace",
+			],
+			"default": ""
 		}
 	]
 }


### PR DESCRIPTION
So windows users can share the command with others. Also, add a prompt to include `--trace` flag when running the task.