### PR TITLE
Add missing new line when printing empty arrays

### DIFF
--- a/jolie/src/main/java/jolie/runtime/ValuePrettyPrinter.java
+++ b/jolie/src/main/java/jolie/runtime/ValuePrettyPrinter.java
@@ -123,7 +123,7 @@ public class ValuePrettyPrinter {
 			if( entry.getValue().isEmpty() ) {
 				writeIndented( childrenIt.hasNext() ? "├─── " : "╰─── ", hasMore );
 				writer.write( entry.getKey() );
-				writer.write( " (empty array)" );
+				writer.write( " (empty array)\n" );
 			} else {
 				int size = entry.getValue().size();
 				Iterator< Value > elementsIt = entry.getValue().iterator();


### PR DESCRIPTION
All the branches of this method end up printing a new line (either via recursion or the base case of `writeNativeValue`), except in the case of an empty array. This patches adds the missing new line character.