### PR TITLE
Skip importing import symbols on wildcards.

### DIFF
--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
@@ -828,6 +828,12 @@ public class SymbolReferenceResolver {
 				if( importedSymbol instanceof WildcardImportedSymbolInfo ) {
 					ModuleRecord wildcardImportedRecord =
 						this.moduleMap.get( importedSymbol.moduleSource().get().uri() );
+					
+					// Resolve the target module referencing before importing in to the main module record,
+					// So it do not need the extra information on the importing symbols.
+					SymbolReferenceResolverVisitor resolver = new SymbolReferenceResolverVisitor();
+					resolver.visit( wildcardImportedRecord.program() );
+
 					md.symbolTable().resolveWildcardImport( (WildcardImportedSymbolInfo) importedSymbol,
 						wildcardImportedRecord.symbolTable().symbols() );
 				} else if( importedSymbol.node() == null ) {

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolTable.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolTable.java
@@ -68,6 +68,10 @@ public class SymbolTable {
 	protected void resolveWildcardImport( WildcardImportedSymbolInfo wildCardSymbol,
 		SymbolInfo... sourceSymbols ) throws DuplicateSymbolException {
 		for( SymbolInfo symbolFromWildcard : sourceSymbols ) {
+			if( symbolFromWildcard instanceof ImportedSymbolInfo ) {
+				// we skips the importing symbols in the target module to polluting the main module record
+				continue;
+			}
 			if( isDuplicateSymbol( symbolFromWildcard.name() ) ) {
 				throw new DuplicateSymbolException( symbolFromWildcard.name() );
 			}


### PR DESCRIPTION
Fixes issue on #457 by resolving the reference of the wildcard import target before adding the available symbols to the symbol table. Then we could prevent polluting the symbol table by skipping the imported symbols to be included in the main symbol table when resolving wild card import statements.