### PR TITLE
Specify docker latest tag to use runtime image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: jolielang/jolie
+          flavor: |
+            latest=true
           tags: |
             type=edge
             type=semver,pattern={{version}}
@@ -47,6 +49,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: jolielang/jolie
+          flavor: |
+            latest=false
           tags: |
             type=edge,suffix=-alpine
             type=semver,pattern={{version}},suffix=-alpine
@@ -56,6 +60,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: jolielang/jolie
+          flavor: |
+            latest=false
           tags: |
             type=edge,suffix=-dev
             type=semver,pattern={{version}},suffix=-dev


### PR DESCRIPTION
This to prevent default behavior of latest tag on Dockerhub to use last successful build as latest tag, so it is using the dev tag since the image take longest to build. 

for more detail on `flavor` https://github.com/docker/metadata-action#flavor-input. 