### PR TITLE
string-utils.ol - fix percentage test

### DIFF
--- a/test/library/string-utils.ol
+++ b/test/library/string-utils.ol
@@ -40,7 +40,7 @@ service Main {
 			if( fmt@su( { format = template, locale = "en-us", data.files = 12312332 } ) != "The disk contains 12,312,332 file(s)" )
 				throw( TestFailed, "The disk contains 12,312,332 file(s)" )
 
-			if( fmt@su( "Up to {pct,number,percent}" { pct = 0.6 } ) != "Up to 60%" )
+			if( fmt@su( { format = "Up to {pct,number,percent}", locale = "en-us", data.pct = 0.6 } ) != "Up to 60%" )
 				throw( TestFailed, "Up to 60%" )
 		}
 	}


### PR DESCRIPTION
We need to provide the locale for the percentage test.