### PR TITLE
HttpProtocol.java - do not provide provide a payload for one-way responses and req/resp ones with return type void

### DIFF
--- a/jolie/src/main/java/jolie/runtime/typing/Type.java
+++ b/jolie/src/main/java/jolie/runtime/typing/Type.java
@@ -322,6 +322,9 @@ public abstract class Type implements Cloneable {
 	public static final Type UNDEFINED =
 		Type.create( BasicType.fromBasicTypeDefinition( BasicTypeDefinition.of( NativeType.ANY ) ),
 			new Range( 0, Integer.MAX_VALUE ), true, null );
+	public static final Type VOID =
+		Type.create( BasicType.fromBasicTypeDefinition( BasicTypeDefinition.of( NativeType.VOID ) ),
+			new Range( 1, 1 ), false, null );
 
 	public static Type create(
 		BasicType< ? > basicType,
@@ -413,6 +416,15 @@ public abstract class Type implements Cloneable {
 	public Value cast( Value value )
 		throws TypeCastingException {
 		return cast( value, new StringBuilder( "#Message" ) );
+	}
+
+	public boolean isVoid() {
+		if( !(this instanceof TypeImpl) )
+			return false;
+		TypeImpl t = (TypeImpl) this;
+		return t.basicType().equals( BasicType.fromBasicTypeDefinition( BasicTypeDefinition.of( NativeType.VOID ) ) )
+			&& t.cardinality().equals( new Range( 1, 1 ) )
+			&& (t.subTypes() == null || t.subTypes().isEmpty());
 	}
 
 	public abstract Optional< Type > getMinimalType( Value value );

--- a/test/extensions/http_features.ol
+++ b/test/extensions/http_features.ol
@@ -86,6 +86,14 @@ define doTest
 			checkResponse2;
 			if ( statusCode != 200 ) { // OK
 				throw( TestFailed, "Wrong HTTP status code" )
+			};
+			consume@Server( reqVal )( );
+			if ( statusCode != 204 ) { // No Content
+				throw( TestFailed, "Wrong HTTP status code" )
+			};
+			consume2@Server( reqVal );
+			if ( statusCode != 204 ) { // No Content
+				throw( TestFailed, "Wrong HTTP status code" )
 			}
 		};
 
@@ -110,6 +118,22 @@ define doTest
 		if ( statusCode != 403 ) { // Forbidden
 			throw( TestFailed, "Wrong HTTP status code" )
 		};
+		scope( s ) {
+			install( TypeMismatch => nullProcess );
+			consume@Server( reqVal )( )
+		};
+		if ( statusCode != 403 ) { // Forbidden
+			throw( TestFailed, "Wrong HTTP status code" )
+		};
+		/* not possible yet since for One-Way operations we may not change the return status code
+		scope( s ) {
+			install( TypeMismatch => nullProcess );
+			consume2@Server( reqVal )
+		};
+		if ( statusCode != 403 ) { // Forbidden
+			throw( TestFailed, "Wrong HTTP status code" )
+		};
+		*/
 
 		if ( keepAlive ) {
 			keepAlive = false // now re-test with on-demand connections

--- a/test/extensions/http_osc.ol
+++ b/test/extensions/http_osc.ol
@@ -26,7 +26,7 @@ include "console.iol"
 
 interface HTTPInterface {
 RequestResponse:
-	default(undefined)(undefined)
+	default( undefined )( undefined ) throws NotFound
 }
 
 
@@ -44,14 +44,16 @@ Jolie:
 }
 
 
-
 define doTest
 {
-	
-	default@Server()( response )
-	if ( response.( "@header").statusCode == "501" ) {
-		throw( TestFailed, "Status code 200 expected")
-	}
-	
-}
+	default@Server()( response ); // first call: 200 Ok/204 No Content
+	if ( response.( "@header" ).statusCode != "200"
+		&& response.( "@header" ).statusCode != "204" ) {
+		throw( TestFailed, "Status code 200/204 expected: " + response.( "@header" ).statusCode )
+	};
 
+	default@Server()( response ); // second call: 404 Not Found
+	if ( response.( "@header" ).statusCode != "404" ) {
+		throw( TestFailed, "Status code 404 expected: " + response.( "@header" ).statusCode )
+	}
+}

--- a/test/extensions/http_post.ol
+++ b/test/extensions/http_post.ol
@@ -80,7 +80,20 @@ define test
 	checkResponse2;
 	format = "binary"; // binary
 	identity@Server( reqVal )( response2 );
-	checkResponse2
+	checkResponse2;
+	// no response checking here, it just needs to pass
+	format = "html"; // HTML
+	consume@Server( reqVal )( );
+	format = "raw"; // plain-text
+	consume@Server( reqVal )( );
+	format = "binary"; // binary
+	consume@Server( reqVal )( );
+	format = "html"; // HTML
+	consume2@Server( reqVal );
+	format = "raw"; // plain-text
+	consume2@Server( reqVal );
+	format = "binary"; // binary
+	consume2@Server( reqVal )
 }
 
 define doTest

--- a/test/extensions/private/http_features_server.ol
+++ b/test/extensions/private/http_features_server.ol
@@ -41,10 +41,12 @@ type HeaderIdentity:any {
 
 interface HeadersServerInterface {
 OneWay:
-	shutdown(undefined)
+	shutdown(undefined),
+	consume2(HeaderIdentity)
 RequestResponse:
 	echoPerson(HeaderPerson)(undefined),
-	identity(HeaderIdentity)(undefined)
+	identity(HeaderIdentity)(undefined),
+	consume(HeaderIdentity)(void)
 }
 
 execution { single }
@@ -80,6 +82,13 @@ main
 		[ identity( request )( response ) {
 			handleRequest
 		} ]
+		[ consume( request )( ) {
+			statusCode = 204;
+			if ( request.Authorization != "TOP_SECRET" ) {
+				statusCode = 403 // Forbidden
+			}
+		} ]
+		[ consume2( request ) ]
 	until
 		[ shutdown() ]
 }

--- a/test/extensions/private/http_server.iol
+++ b/test/extensions/private/http_server.iol
@@ -37,8 +37,10 @@ type Person:void {
 
 interface ServerInterface {
 OneWay:
-	shutdown(void)
+	shutdown(void),
+	consume2(any)
 RequestResponse:
 	echoPerson(Person)(Person),
-	identity(any)(any)
+	identity(any)(any),
+	consume(any)(void)
 }

--- a/test/extensions/private/http_server.ol
+++ b/test/extensions/private/http_server.ol
@@ -43,6 +43,10 @@ main
 			undef( response );
 			response << request
 		} ]
+		[ consume( request )( ) {
+			nullProcess
+		} ]
+		[ consume2( request ) ]
 	until
 		[ shutdown() ]
 }

--- a/test/extensions/private/http_server2.ol
+++ b/test/extensions/private/http_server2.ol
@@ -41,6 +41,10 @@ main
 			undef( response );
 			response << request
 		} ]
+		[ consume( request )( ) {
+			nullProcess
+		} ]
+		[ consume2( request ) ]
 	until
 		[ shutdown() ]
 }

--- a/test/extensions/private/http_server_osc.ol
+++ b/test/extensions/private/http_server_osc.ol
@@ -22,9 +22,8 @@
 
 interface HTTPInterface {
 RequestResponse:
-	default(undefined)(undefined)
+	default( undefined )( undefined ) throws NotFound
 }
-
 
 execution { single }
 
@@ -32,13 +31,17 @@ inputPort ServerInput {
 Location: "socket://localhost:10101"
 Protocol: http {
 	.osc.default.cookies.sid = "sid"
+	.osc.default.statusCodes.NotFound = 404
 }
 Interfaces: HTTPInterface
 }
 
 main
 {
-	default( request )( response ) {
+	default( )( ) {
 		nullProcess
+	};
+	default( )( ) {
+		throw( NotFound )
 	}
 }

--- a/test/extensions/private/https_server.ol
+++ b/test/extensions/private/https_server.ol
@@ -44,6 +44,10 @@ main
 			undef( response );
 			response << request
 		} ]
+		[ consume( request )( ) {
+			nullProcess
+		} ]
+		[ consume2( request ) ]
 	until
 		[ shutdown() ]
 }

--- a/test/extensions/private/jsonrpc_server.ol
+++ b/test/extensions/private/jsonrpc_server.ol
@@ -41,6 +41,10 @@ main
 			undef( response );
 			response << request
 		} ]
+		[ consume( request )( ) {
+			nullProcess
+		} ]
+		[ consume2( request ) ]
 	until
 		[ shutdown() ]
 }

--- a/test/extensions/private/server.iol
+++ b/test/extensions/private/server.iol
@@ -47,8 +47,10 @@ type Person:void {
 
 interface ServerInterface {
 OneWay:
-	shutdown(void)
+	shutdown(void),
+	consume2(any)
 RequestResponse:
 	echoPerson(Person)(Person),
-	identity(any)(any)
+	identity(any)(any),
+	consume(any)(void)
 }

--- a/test/extensions/private/soap_server.ol
+++ b/test/extensions/private/soap_server.ol
@@ -41,6 +41,10 @@ main
 			undef( response );
 			response << request
 		} ]
+		[ consume( request )( ) {
+			nullProcess
+		} ]
+		[ consume2( request ) ]
 	until
 		[ shutdown() ]
 }

--- a/test/extensions/private/sodep_server.ol
+++ b/test/extensions/private/sodep_server.ol
@@ -41,6 +41,10 @@ main
 			undef( response );
 			response << request
 		} ]
+		[ consume( request )( ) {
+			nullProcess
+		} ]
+		[ consume2( request ) ]
 	until
 		[ shutdown() ]
 }

--- a/test/extensions/private/sodeps_server.ol
+++ b/test/extensions/private/sodeps_server.ol
@@ -44,6 +44,10 @@ main
 			undef( response );
 			response << request
 		} ]
+		[ consume( request )( ) {
+			nullProcess
+		} ]
+		[ consume2( request ) ]
 	until
 		[ shutdown() ]
 }

--- a/test/extensions/server.ol
+++ b/test/extensions/server.ol
@@ -133,30 +133,44 @@ define test
 {
 	echoPerson@SODEPServer( person )( response );
 	identity@SODEPServer( reqVal )( response2 );
+	consume@SODEPServer( reqVal )( );
+	consume2@SODEPServer( reqVal );
 	checkResponse;
 	echoPerson@SODEPSServer( person )( response );
 	identity@SODEPSServer( reqVal )( response2 );
+	consume@SODEPSServer( reqVal )( );
+	consume2@SODEPSServer( reqVal );
 	checkResponse;
 
 	echoPerson@SOAPServer( person )( response );
 	identity@SOAPServer( reqVal )( response2 );
+	consume@SOAPServer( reqVal )( );
+	consume2@SOAPServer( reqVal );
 	checkResponse;
 
 	echoPerson@JSONRPCServer( person )( response );
 	identity@JSONRPCServer( reqVal )( response2 );
+	consume@JSONRPCServer( reqVal )( );
+	consume2@JSONRPCServer( reqVal );
 	checkResponse;
 
 	method = "post";
 	format = "xml";
 	echoPerson@HTTPServer( person )( response );
 	identity@HTTPServer( reqVal )( response2 );
+	consume@HTTPServer( reqVal )( );
+	consume2@HTTPServer( reqVal );
 	checkResponse;
 	echoPerson@HTTPSServer( person )( response );
 	identity@HTTPSServer( reqVal )( response2 );
+	consume@HTTPSServer( reqVal )( );
+	consume2@HTTPSServer( reqVal );
 	checkResponse;
 	format = "json";
 	echoPerson@HTTPServer( person )( response );
 	identity@HTTPServer( reqVal )( response2 );
+	consume@HTTPServer( reqVal )( );
+	consume2@HTTPServer( reqVal );
 	checkResponse;
 	echoPerson@HTTPSServer( person )( response );
 	identity@HTTPSServer( reqVal )( response2 );
@@ -164,9 +178,13 @@ define test
 	method = "get"; // JSON-ified
 	echoPerson@HTTPServer( person )( response );
 	identity@HTTPServer( reqVal )( response2 );
+	consume@HTTPServer( reqVal )( );
+	consume2@HTTPServer( reqVal );
 	checkResponse;
 	echoPerson@HTTPSServer( person )( response );
 	identity@HTTPSServer( reqVal )( response2 );
+	consume@HTTPSServer( reqVal )( );
+	consume2@HTTPSServer( reqVal );
 	checkResponse
 }
 


### PR DESCRIPTION
HTTP server one-way responses should not provide a payload and a content-type: 0 header. This behaviour is required for compatibility with certain HTTP operations as "204 No Content".