### PR TITLE
Add YAML support to readFile@files

### DIFF
--- a/javaServices/coreJavaServices/pom.xml
+++ b/javaServices/coreJavaServices/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
     </properties>
     <name>coreJavaServices</name>
     <description>Core Java services.</description>
@@ -586,6 +586,11 @@
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
             <version>0.9.10</version>
+        </dependency>
+        <dependency>
+            <groupId>org.snakeyaml</groupId>
+            <artifactId>snakeyaml-engine</artifactId>
+            <version>2.7</version>
         </dependency>
     </dependencies>
 </project>

--- a/packages/file.ol
+++ b/packages/file.ol
@@ -38,6 +38,7 @@ type ReadFileRequest {
 	format?:string { // "text" (default), "base64" (same as "binary" but afterwards base64-encoded), "binary", "xml" (a type-annotated XML format), "xml_store", "properties" (Java properties file) or "json"
 		charset?:string // set the encoding. Default: system (eg. for Unix-like OS UTF-8), header specification (XML) or format's default (for XML and JSON UTF-8)
 		skipMixedText?: bool // in case of format xml, it skips the mixed elements
+		stream?:bool //< if format is "yaml" and this is true, the file is read as a stream of multiple YAML documents
 	}
 }
 

--- a/packages/file.ol
+++ b/packages/file.ol
@@ -38,7 +38,7 @@ type ReadFileRequest {
 	format?:string { // "text" (default), "base64" (same as "binary" but afterwards base64-encoded), "binary", "xml" (a type-annotated XML format), "xml_store", "properties" (Java properties file) or "json"
 		charset?:string // set the encoding. Default: system (eg. for Unix-like OS UTF-8), header specification (XML) or format's default (for XML and JSON UTF-8)
 		skipMixedText?: bool // in case of format xml, it skips the mixed elements
-		stream?:bool //< if format is "yaml" and this is true, the file is read as a stream of multiple YAML documents
+		stream?:bool //< if format is "yaml" and this is true, the file is read as a stream of multiple YAML documents which will be returned as a "documents" array in the response
 	}
 }
 

--- a/test/library/files-yaml.ol
+++ b/test/library/files-yaml.ol
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024 Fabrizio Montesi <famontesi@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+from ..test-unit import TestUnitInterface
+from file import File
+from assertions import Assertions
+
+/**
+	A template for test units.
+*/
+service Main {
+	inputPort TestUnitInput {
+		location: "local"
+		interfaces: TestUnitInterface
+	}
+
+	embed File as file
+	embed Assertions as assertions
+
+	main {
+		test()() {
+			getServiceDirectory@file()( dir )
+			getFileSeparator@file()( fs )
+
+			yamlFilename = dir + fs + "private" + fs + "yaml-test.yaml"
+
+			readFile@file( { filename = yamlFilename, format = "yaml" } )( yamlDoc )
+
+			scope( yamlChecks ) {
+				install( AssertionError => throw TestFailed( yamlChecks.AssertionError ) )
+
+				equals@assertions( {
+					actual << yamlDoc
+					expected << {
+						news[0] << {
+							title = "News 1"
+							date = "2024-01-01"
+							content = "Content 1"
+						}
+						news[1] << {
+							title = "News 2"
+							date = "2024-02-02"
+							content = "Content 2"
+						}
+					}
+				} )()
+			}
+		}
+	}
+}

--- a/test/library/private/yaml-test.yaml
+++ b/test/library/private/yaml-test.yaml
@@ -1,0 +1,7 @@
+news:
+  - title: "News 1"
+    date: "2024-01-01"
+    content: "Content 1"
+  - title: "News 2"
+    date: "2024-02-02"
+    content: "Content 2"


### PR DESCRIPTION
This pull request adds support for reading YAML documents to readFile@File. It also includes a change to the `ReadFileRequest` type to include a new `stream` parameter, which allows for reading a file containing multiple YAML documents.