### PR TITLE
fix for showing line number correctly when using --trace

### DIFF
--- a/jolie/src/main/java/jolie/tracer/PrintingTracer.java
+++ b/jolie/src/main/java/jolie/tracer/PrintingTracer.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.function.Supplier;
-
 import jolie.Interpreter;
 import jolie.runtime.Value;
 import jolie.runtime.ValuePrettyPrinter;
@@ -91,7 +90,7 @@ public class PrintingTracer implements Tracer {
 				stBuilder.append( interpreter.logPrefix() ).append( "\t" );
 			} else {
 				stBuilder.append( action.context().sourceName() ).append( ":" )
-					.append( action.context().startLine() + 1 );
+					.append( action.context().startLine() + 1 ).append( "\t" );
 			}
 			stBuilder.append( actionCounter ).append( ".\t" );
 			switch( action.type() ) {
@@ -152,7 +151,7 @@ public class PrintingTracer implements Tracer {
 				stBuilder.append( interpreter.logPrefix() ).append( "\t" );
 			} else {
 				stBuilder.append( action.context().sourceName() ).append( ":" )
-					.append( action.context().startLine() + 1 );
+					.append( action.context().startLine() + 1 ).append( "\t" );
 			}
 			stBuilder.append( actionCounter ).append( ".\t" );
 			switch( action.type() ) {
@@ -200,7 +199,7 @@ public class PrintingTracer implements Tracer {
 				stBuilder.append( interpreter.logPrefix() ).append( "\t" );
 			} else {
 				stBuilder.append( action.context().sourceName() ).append( ":" )
-					.append( action.context().startLine() + 1 );
+					.append( action.context().startLine() + 1 ).append( "\t" );
 			}
 			stBuilder.append( actionCounter ).append( ".\t" );
 			switch( action.type() ) {


### PR DESCRIPTION
When running a file with --trace the line numbering was incorrectly printed, E.G. these should be 62 and 204:
/workspaces/jolie/ex1.ol:6297.     << SR
/workspaces/jolie/ex1.ol:20447.   :: ASSIGNMENT

This happens because there is no whitespace between the line number and actionCounter.

This commit fixes that, so the lines look like:
/workspaces/jolie/ex1.ol:62     97.     << SR
/workspaces/jolie/ex1.ol:204   47.     :: ASSIGNMENT