### PR TITLE
added hashCode@Values

### DIFF
--- a/javaServices/coreJavaServices/src/main/java/joliex/lang/Values.java
+++ b/javaServices/coreJavaServices/src/main/java/joliex/lang/Values.java
@@ -3,6 +3,7 @@
  *   Copyright (C) 2018 by Larisa Safina <safina@imada.sdu.dk>
  *   Copyright (C) 2018 by Stefano Pio Zingaro <stefanopio.zingaro@unibo.it>
  *   Copyright (C) 2018 by Saverio Giallorenzo <saverio.giallorenzo@gmail.com>
+ *   Copyright (C) 2024 by Marco Peressotti <marco.peressotti@gmail.com>
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU Library General Public License as
@@ -24,6 +25,8 @@
 
 package joliex.lang;
 
+import java.util.SortedSet;
+import java.util.TreeSet;
 import jolie.runtime.JavaService;
 import jolie.runtime.Value;
 import jolie.runtime.ValueVector;
@@ -112,4 +115,55 @@ public class Values extends JavaService {
 			return false;
 		}
 	}
+	
+	/**
+	 * Returns a hash code value for the argument.
+	 * @param request
+	 * @return has code
+	 */
+	public Integer hashCode( Value request ) {
+		return Values.hash( request );
+	}
+
+	/* The implementation of equals and hash must guarantee that
+	 * equals(v1,v2) implies hash(v1) == hash(v2)
+	 */
+	private static int hash( Value value ) {
+		int hashCode = 0;
+		if( value != null ) {
+			try {
+				if( value.isDefined() ) {
+					if( value.isByteArray() ) {
+						hashCode = value.byteArrayValueStrict().hashCode();
+					} else if( value.isString() ) {
+						hashCode = value.strValueStrict().hashCode();
+					} else if( value.isInt() ) {
+						hashCode = Integer.hashCode( value.intValueStrict() );
+					} else if( value.isDouble() ) {
+						hashCode = Double.hashCode( value.doubleValueStrict() );
+					} else if( value.isBool() ) {
+						hashCode = Boolean.hashCode( value.boolValueStrict() );
+					} else if( value.isLong() ) {
+						hashCode = Long.hashCode( value.longValueStrict() );
+					} else {
+						hashCode = java.util.Objects.hashCode( value.valueObject() );
+					}
+				}
+			} catch( TypeCastingException ignored ) {
+			}
+			/* Similarly to java collections, each increment is weighted to spread 
+			 * out codes. To guarantee correctness of the result wrt equals, the 
+			 * order in which children are visited must be deterministic hence, keys 
+			 * are sorted.
+			 */
+			SortedSet< String > keys = new TreeSet<>( value.children().keySet() );
+			for( String key : keys ) {
+				for( Value v : value.getChildren( key ) ) {
+					hashCode = 31 * hashCode + hash( v );
+				}
+			}
+		}
+		return hashCode;
+	}
+
 }

--- a/packages/values.ol
+++ b/packages/values.ol
@@ -1,5 +1,5 @@
 /*
- *   Copyright (C) 2022 by Fabrizio Montesi <famontesi@gmail.com>     
+ *   Copyright (C) 2022 by Fabrizio Montesi <famontesi@gmail.com> 
  *                                                                         
  *   This program is free software; you can redistribute it and/or modify  
  *   it under the terms of the GNU Library General Public License as       
@@ -20,17 +20,24 @@
  */
 
 type ComparisonRequest {
-	fst:undefined
-	snd:undefined
+	fst:undefined //< The first value
+	snd:undefined //< The second value
 }
 
 interface ValuesInterface {
-RequestResponse:
-	equals(ComparisonRequest)(bool)
+	requestResponse:
+		/**
+		 * Returns true if two values are deeply equal to each other and false otherwise.
+		 */
+		equals(ComparisonRequest)(bool),
+		/**
+		 * Returns a hash code value for the argument.
+		 */
+		hashCode(undefined)(int)
 }
 
 service Values {
-	inputPort Input {
+	inputPort input {
 		location: "local"
 		interfaces: ValuesInterface
 	}

--- a/test/library/values.ol
+++ b/test/library/values.ol
@@ -19,12 +19,14 @@
 
 from ..test-unit import TestUnitInterface
 from values import Values
+from console import Console
 
 /**
 	A template for test units.
 */
 service Main {
 	embed Values as values
+	embed Console as console
 
 	inputPort TestUnitInput {
 		location: "local"
@@ -35,7 +37,7 @@ service Main {
 		test()() {
 			person << {
 				name = "Homer"
-			   	age = 42
+				age = 42
 				interests[0] = "beer"
 				interests[1] = "hockey"
 			}
@@ -74,6 +76,24 @@ service Main {
 				}
 			} ) ) {
 				throw( TestFailed, "value equality does not match expected result" )
+			}
+
+			if( hashCode@values( void ) != 0 ) {
+			 	throw( TestFailed, "value hashCode does not match expected result" )
+			}
+
+			if( hashCode@values( person ) != hashCode@values( person ) ) {
+			 	throw( TestFailed, "value hashCode does not match expected result" )
+			}
+
+			person2 -> person
+			if( hashCode@values( person ) != hashCode@values( person2 ) ) {
+			 	throw( TestFailed, "value hashCode does not match expected result" )
+			}
+
+			person3 << person
+			if( hashCode@values( person ) != hashCode@values( person3 ) ) {
+			 	throw( TestFailed, "value hashCode does not match expected result" )
 			}
 		}
 	}


### PR DESCRIPTION
This adds the operation `hashCode` to service `Values` for computing a hash code of Jolie values. If `equals@Values` returns true on a pair of values, then `hashCode@Values` will return the same hash code for each of them. 