### PR TITLE
fix JSON converter finds correct subtype if subtypes in TypeChoice has same name

### DIFF
--- a/jolie/src/main/java/jolie/runtime/typing/Type.java
+++ b/jolie/src/main/java/jolie/runtime/typing/Type.java
@@ -60,7 +60,7 @@ class TypeImpl extends Type {
 		}
 
 		try {
-			checkSubType.check( value ); //checks if the value is of the the given type (I think)
+			checkSubType.check( value );
 			return checkSubType;
 		} catch( TypeCheckingException e ) {
 			return null;

--- a/jolie/src/main/java/jolie/runtime/typing/Type.java
+++ b/jolie/src/main/java/jolie/runtime/typing/Type.java
@@ -21,16 +21,15 @@
 
 package jolie.runtime.typing;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
 import jolie.lang.NativeType;
 import jolie.lang.parse.ast.types.BasicTypeDefinition;
 import jolie.runtime.Value;
 import jolie.runtime.ValueVector;
 import jolie.util.Range;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
 
 class TypeImpl extends Type {
 	private final Range cardinality;
@@ -50,6 +49,21 @@ class TypeImpl extends Type {
 	@Override
 	public Type findSubType( String key ) {
 		return (subTypes != null) ? subTypes.get( key ) : null;
+	}
+
+	public Type findSubType( String key, Value value ) {
+
+		Type checkSubType = findSubType( key );
+		if( checkSubType == null ) {
+			return null;
+		}
+
+		try {
+			checkSubType.check( value ); //checks if the value is of the the given type (I think)
+			return checkSubType;
+		} catch( TypeCheckingException e ) {
+			return null;
+		}
 	}
 
 	@Override
@@ -258,6 +272,11 @@ class TypeChoice extends Type {
 		return (ret != null) ? ret : right.findSubType( key );
 	}
 
+	@Override
+	public Type findSubType( String key, Value value ) {
+		Type ret = left.findSubType( key, value );
+		return (ret != null) ? ret : right.findSubType( key, value );
+	}
 
 	@Override
 	public void cutChildrenFromValue( Value value ) {
@@ -436,6 +455,8 @@ public abstract class Type {
 
 	public abstract Type findSubType( String key );
 
+	public abstract Type findSubType( String key, Value value );
+
 	protected abstract void check( Value value, StringBuilder pathBuilder )
 		throws TypeCheckingException;
 
@@ -455,6 +476,10 @@ public abstract class Type {
 		@Override
 		public Type findSubType( String key ) {
 			return linkedType.findSubType( key );
+		}
+
+		public Type findSubType( String key, Value value ) {
+			return linkedType.findSubType( key, value );
 		}
 
 		public String linkedTypeName() {

--- a/jolie/src/main/java/jolie/runtime/typing/Type.java
+++ b/jolie/src/main/java/jolie/runtime/typing/Type.java
@@ -51,6 +51,7 @@ class TypeImpl extends Type {
 		return (subTypes != null) ? subTypes.get( key ) : null;
 	}
 
+	@Override
 	public Type findSubType( String key, Value value ) {
 
 		Type checkSubType = findSubType( key );
@@ -478,6 +479,7 @@ public abstract class Type {
 			return linkedType.findSubType( key );
 		}
 
+		@Override
 		public Type findSubType( String key, Value value ) {
 			return linkedType.findSubType( key, value );
 		}

--- a/lib/jolie-js/src/main/java/jolie/js/JsUtils.java
+++ b/lib/jolie-js/src/main/java/jolie/js/JsUtils.java
@@ -28,13 +28,13 @@ import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import jolie.runtime.Value;
-import jolie.runtime.ValueVector;
-import jolie.runtime.typing.Type;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.json.simple.parser.ParseException;
+import jolie.runtime.Value;
+import jolie.runtime.ValueVector;
+import jolie.runtime.typing.Type;
 
 public class JsUtils {
 	/**
@@ -110,7 +110,8 @@ public class JsUtils {
 			}
 			int i = 0;
 			for( Map.Entry< String, ValueVector > child : value.children().entrySet() ) {
-				final Type subType = (type != null ? type.findSubType( child.getKey() ) : null);
+				final Type subType =
+					(type != null ? type.findSubType( child.getKey(), child.getValue().first() ) : null);
 				appendKeyColon( builder, child.getKey() );
 				valueVectorToJsonString( child.getValue(), builder, false, subType );
 				if( i++ < size - 1 ) {

--- a/test/extensions/http_json.ol
+++ b/test/extensions/http_json.ol
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 Niels Erik Jepsen
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+include "../AbstractTestUnit.iol"
+
+interface Iface {
+    RequestResponse: AB(void)(string)
+	RequestResponse: BA(void)(string)
+}
+
+outputPort Server {
+	Location: "socket://localhost:12345"
+	Protocol: http {
+		format = "json"
+	}
+	Interfaces: Iface
+}
+
+embedded {
+Jolie:
+	"private/http_json_server.ol"
+}
+
+constants {
+	correctResponce = "{\"sameName\":{\"anArray\":[\"Should be wrapped in an array\"],\"sameName\":\"\"}}"
+}
+
+define doTest
+{
+	AB@Server()( ABResponse )
+	BA@Server()( BAResponse ) 
+
+	if ( ABResponse != correctResponce) {
+		if ( BAResponse != correctResponce) {
+			throw( TestFailed, "Both type AB and BA does not fit correct response." )
+		} else {
+			throw( TestFailed, "Type AB does not fit correct response." )
+		}
+	}
+
+	if ( BAResponse != correctResponce) {
+		throw( TestFailed, "Type BA does not fit correct response." )
+	}
+	
+	
+}

--- a/test/extensions/private/http_json_server.ol
+++ b/test/extensions/private/http_json_server.ol
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 Niels Erik Jepsen
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+type BAResponse: B | A
+type ABResponse: A | B
+
+type A {
+    anArray*: undefined
+    sameName: string
+}
+
+type B {
+    sameName?: A
+}
+
+interface Iface {
+    RequestResponse: AB(void)(BAResponse)
+	RequestResponse: BA(void)(ABResponse)
+}
+
+define makeResponse
+{
+    //sameName is required to have the same name to test that the correct type is found when converting the type to json
+	Response << {
+		sameName << {
+			anArray[0] = "Should be wrapped in an array"
+			sameName = ""
+		}
+	}
+} 
+
+service json_server {
+    execution: concurrent
+    inputPort ip {
+        location: "socket://localhost:12345"
+        protocol: http {
+            format = "json"
+		    .contentType = "text/plain" //< overwrite the output format to 
+        }
+        interfaces: Iface
+    }
+    main {
+        [AB()(Response) {
+            makeResponse
+         }]
+		[BA()(Response) {
+            makeResponse
+         }] 
+    }
+}
+


### PR DESCRIPTION
added findSubType that takes a String and a Value, and finds the Type which also corresponds to the Value
valueToJsonString in JsUtils.java now uses the new method to find the correct subtype

This is to fix the issue reported in discord:
sundedrengen — 10/29/2024 2:02 AM
We are pretty sure we found a bug in the way Jolie generates json reponses in the following circumstance (tested on jolie commit 3b8c752):
```
//Doesn't happen if type is 
//type Response: B | A
type Response: A | B

type A {
    canbeanything*: undefined
    test: string
}

type B {
    test?: A
}

interface Iface {
    RequestResponse: hello(void)(Response)
}

service BugHunter {
    execution: concurrent
    inputPort ip {
        location: "socket://localhost:12345"
        protocol: http {format = "json"}
        interfaces: Iface
    }
    main {
        [hello()(Response) {
            Response << {
                test << {
                    canbeanything[0] = "This should be wrapped in an array"
                    test = ""
                    //Not wrapped because something with the same name (in this case "test") exists in both of the types (we think).
                    /*
                    curl localhost:12345/hello
                    {"test":{"test":"","canbeanything":"This should be wrapped in an array"}}
                    */
                }
            }
         }]
    }
}
```

Not sure if it is done in the correct way.