### PR TITLE
std lib generator triggered only when packages is modified

### DIFF
--- a/.github/workflows/stdlibs-docs.yml
+++ b/.github/workflows/stdlibs-docs.yml
@@ -5,12 +5,29 @@ on:
   workflow_run:
     workflows:
       - Java CI
+      - Publish Release
     types:
       - completed
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: Test packages changed-files
+    outputs:
+      any_changed: ${{ steps.changed-files-in-packages.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get changed files in packages
+        id: changed-files-in-packages
+        uses: tj-actions/changed-files@v45
+        with:
+          files: packages/**
   build:
     runs-on: ubuntu-latest
+    needs: check
+    if: contains(needs.check.outputs.any_changed, 'true')
     outputs:
       jolie_version: ${{ steps.jolie_version.outputs.jolie_version }}
       summary_string: ${{ steps.generate.outputs.summary_string }}


### PR DESCRIPTION
This PR reduces noise in the Jolie ecosystem by scoping the trigger event of std lib generation to only trigger when content in packages dir is modified.