### PR TITLE
Use Java 21 in libjolie

### DIFF
--- a/libjolie/pom.xml
+++ b/libjolie/pom.xml
@@ -13,7 +13,7 @@
 	<packaging>jar</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.release>11</maven.compiler.release>
+		<maven.compiler.release>21</maven.compiler.release>
 	</properties>
 	<name>libjolie</name>
 	<description>Java library for parsing and analysing Jolie code.</description>


### PR DESCRIPTION
Up the Java version in libjolie to Java 21 so Record classes can be used. 