### PR TITLE
Add LSP-style Location to ParsingContext.

### DIFF
--- a/libjolie/src/main/java/jolie/lang/parse/context/Location.java
+++ b/libjolie/src/main/java/jolie/lang/parse/context/Location.java
@@ -1,23 +1,21 @@
-/***************************************************************************
- *   Copyright (C) 2024 Kasper Okumu <kaspokumu@gmail.com>                 *
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU Library General Public License as       *
- *   published by the Free Software Foundation; either version 2 of the    *
- *   License, or (at your option) any later version.                       *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this program; if not, write to the                 *
- *   Free Software Foundation, Inc.,                                       *
- *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
- *                                                                         *
- *   For details about the authors of this software, see the AUTHORS file. *
- ***************************************************************************/
+/*
+ * Copyright (C) 2025 Kasper Okumu <kaspokumu@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
 
 package jolie.lang.parse.context;
 

--- a/libjolie/src/main/java/jolie/lang/parse/context/Location.java
+++ b/libjolie/src/main/java/jolie/lang/parse/context/Location.java
@@ -1,0 +1,53 @@
+/***************************************************************************
+ *   Copyright (C) 2024 Kasper Okumu <kaspokumu@gmail.com>                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Library General Public License as       *
+ *   published by the Free Software Foundation; either version 2 of the    *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ *                                                                         *
+ *   For details about the authors of this software, see the AUTHORS file. *
+ ***************************************************************************/
+
+package jolie.lang.parse.context;
+
+import jolie.lang.Constants;
+
+import java.io.Serializable;
+import java.net.URI;
+
+/**
+ * Implements of the LSP specification of a Location.
+ *
+ * @see <a href=
+ *      "https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#location">LSP
+ *      location specification</a>
+ * @param documentUri The file of the Location.
+ * @param range The Range in the document.
+ */
+public record Location(URI documentUri, Range range) implements Serializable {
+	private static final long serialVersionUID = Constants.serialVersionUID();
+
+	public Location( URI documentUri, int startLine, int endLine, int startCharacter, int endCharacter ) {
+		this( documentUri,
+			new Range( new Position( startLine, startCharacter ), new Position( endLine, endCharacter ) ) );
+	}
+
+	public Location {
+		if( documentUri == null )
+			throw new IllegalArgumentException( "documentUri cannot be null." );
+		if( range == null )
+			throw new IllegalArgumentException( "range cannot be null" );
+	}
+
+}

--- a/libjolie/src/main/java/jolie/lang/parse/context/Location.java
+++ b/libjolie/src/main/java/jolie/lang/parse/context/Location.java
@@ -27,7 +27,7 @@ import java.io.Serializable;
 import java.net.URI;
 
 /**
- * Implements of the LSP specification of a Location.
+ * Implementation of the LSP specification of a Location.
  *
  * @see <a href=
  *      "https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#location">LSP

--- a/libjolie/src/main/java/jolie/lang/parse/context/ParsingContext.java
+++ b/libjolie/src/main/java/jolie/lang/parse/context/ParsingContext.java
@@ -93,6 +93,15 @@ public interface ParsingContext extends Serializable {
 	List< String > enclosingCodeWithLineNumbers();
 
 	/**
+	 * Returns a Location representation of the ParsingContext.
+	 *
+	 * @return The Location of the ParsingContext.
+	 */
+	default Location location() {
+		return new Location( source(), startLine(), endLine(), startColumn(), endColumn() );
+	}
+
+	/**
 	 * Returns a string interpretations of the ParsingContext
 	 *
 	 * @return a string interpretations of the ParsingContext

--- a/libjolie/src/main/java/jolie/lang/parse/context/Position.java
+++ b/libjolie/src/main/java/jolie/lang/parse/context/Position.java
@@ -1,23 +1,21 @@
-/***************************************************************************
- *   Copyright (C) 2024 Kasper Okumu <kaspokumu@gmail.com>                 *
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU Library General Public License as       *
- *   published by the Free Software Foundation; either version 2 of the    *
- *   License, or (at your option) any later version.                       *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this program; if not, write to the                 *
- *   Free Software Foundation, Inc.,                                       *
- *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
- *                                                                         *
- *   For details about the authors of this software, see the AUTHORS file. *
- ***************************************************************************/
+/*
+ * Copyright (C) 2025 Kasper Okumu <kaspokumu@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
 
 package jolie.lang.parse.context;
 

--- a/libjolie/src/main/java/jolie/lang/parse/context/Position.java
+++ b/libjolie/src/main/java/jolie/lang/parse/context/Position.java
@@ -1,0 +1,46 @@
+/***************************************************************************
+ *   Copyright (C) 2024 Kasper Okumu <kaspokumu@gmail.com>                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Library General Public License as       *
+ *   published by the Free Software Foundation; either version 2 of the    *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ *                                                                         *
+ *   For details about the authors of this software, see the AUTHORS file. *
+ ***************************************************************************/
+
+package jolie.lang.parse.context;
+
+import jolie.lang.Constants;
+import java.io.Serializable;
+
+/**
+ * Implements the LSP specification of a Position.
+ *
+ * @param line The zero-based line of the Position.
+ * @param character The zero-based character offset.
+ * @see <a href=
+ *      "https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position">LSP
+ *      position specification</a>
+ */
+public record Position(int line, int character) implements Serializable {
+	private static final long serialVersionUID = Constants.serialVersionUID();
+
+	// /** FIXME re-add this exception when use of -1 is eliminated
+	// * @throws IllegalArgumentException If line or character are negative.
+	// */
+	// public Position {
+	// if( line < 0 || character < 0 )
+	// throw new IllegalArgumentException( "Position line and character must be non-negative." );
+	// }
+}

--- a/libjolie/src/main/java/jolie/lang/parse/context/Range.java
+++ b/libjolie/src/main/java/jolie/lang/parse/context/Range.java
@@ -1,23 +1,21 @@
-/***************************************************************************
- *   Copyright (C) 2024 Kasper Okumu <kaspokumu@gmail.com>                 *
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU Library General Public License as       *
- *   published by the Free Software Foundation; either version 2 of the    *
- *   License, or (at your option) any later version.                       *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this program; if not, write to the                 *
- *   Free Software Foundation, Inc.,                                       *
- *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
- *                                                                         *
- *   For details about the authors of this software, see the AUTHORS file. *
- ***************************************************************************/
+/*
+ * Copyright (C) 2025 Kasper Okumu <kaspokumu@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
 
 package jolie.lang.parse.context;
 

--- a/libjolie/src/main/java/jolie/lang/parse/context/Range.java
+++ b/libjolie/src/main/java/jolie/lang/parse/context/Range.java
@@ -1,0 +1,48 @@
+/***************************************************************************
+ *   Copyright (C) 2024 Kasper Okumu <kaspokumu@gmail.com>                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Library General Public License as       *
+ *   published by the Free Software Foundation; either version 2 of the    *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ *                                                                         *
+ *   For details about the authors of this software, see the AUTHORS file. *
+ ***************************************************************************/
+
+package jolie.lang.parse.context;
+
+import jolie.lang.Constants;
+
+import java.io.Serializable;
+
+/**
+ * A text document range with zero-based start and end positions. Implements the LSP specification
+ * of a Range.
+ *
+ * @see <a href=
+ *      "https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range">LSP
+ *      range specification</a>
+ * @param start The start Position of the Range.
+ * @param end The end Position of the Range.
+ */
+public record Range(Position start, Position end) implements Serializable {
+	private static final long serialVersionUID = Constants.serialVersionUID();
+
+	public Range {
+		if( start == null )
+			throw new IllegalArgumentException( "Range cannot have a null start." );
+		if( end == null )
+			throw new IllegalArgumentException( "Range cannot have a null end." );
+	}
+
+}


### PR DESCRIPTION
This PR adds record classes related to LSP-style `Location`, and a default method in the `ParsingContext` interface to return a Location.
This will be used in the `ast.ol` package.

Note: The PR replaces my older more complicated PR #546 