### PR TITLE
Refactor interpreter configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,8 @@
 				"-p",
 				"${workspaceFolder}/packages",
 				"${input:trace}",
+				"--responseTimeout",
+				"300000",
 				"${input:programName}"
 			],
 			"windows": {
@@ -27,6 +29,8 @@
 					"-p",
 					"${workspaceFolder}\\packages",
 					"${input:trace}",
+					"--responseTimeout",
+					"300000",
 					"${input:programName}"
 				]
 			}
@@ -74,6 +78,8 @@
 				"-p",
 				"${workspaceFolder}/packages",
 				"${input:trace}",
+				"--responseTimeout",
+				"300000",
 				"test.ol",
 				"${input:testName}"
 			],
@@ -86,6 +92,8 @@
 					"-p",
 					"${workspaceFolder}\\packages",
 					"${input:trace}",
+					"--responseTimeout",
+					"300000",
 					"test.ol",
 					"${input:programName}"
 				]

--- a/extensions/jolie-embedding-legacy/src/main/java/jolie/embedding/jolie/InternalJolieServiceLoader.java
+++ b/extensions/jolie-embedding-legacy/src/main/java/jolie/embedding/jolie/InternalJolieServiceLoader.java
@@ -53,7 +53,6 @@ public class InternalJolieServiceLoader extends EmbeddedServiceLoader {
 			new CommandLineParser( newArgs.toArray( new String[] {} ), currInterpreter.getClassLoader(), true );
 		interpreter = new Interpreter(
 			commandLineParser.getInterpreterConfiguration(),
-			currInterpreter.programDirectory(),
 			currInterpreter,
 			program );
 	}

--- a/extensions/jolie-embedding-legacy/src/main/java/jolie/embedding/jolie/JolieServiceLoader.java
+++ b/extensions/jolie-embedding-legacy/src/main/java/jolie/embedding/jolie/JolieServiceLoader.java
@@ -49,7 +49,6 @@ public class JolieServiceLoader extends EmbeddedServiceLoader {
 		super( channelDest );
 		final String[] ss = SERVICE_PATH_SPLIT_PATTERN.split( servicePath );
 		final String[] options = currInterpreter.optionArgs();
-
 		final String[] newArgs = new String[ 2 + options.length + ss.length ];
 		newArgs[ 0 ] = "-i";
 		newArgs[ 1 ] = currInterpreter.programDirectory().getAbsolutePath();
@@ -60,36 +59,11 @@ public class JolieServiceLoader extends EmbeddedServiceLoader {
 
 		Interpreter.Configuration cmdConfig = commandLineParser.getInterpreterConfiguration();
 		Interpreter.Configuration config = Interpreter.Configuration.create(
-			cmdConfig.connectionsLimit(),
-			cmdConfig.cellId(),
-			cmdConfig.correlationAlgorithm(),
-			cmdConfig.includePaths(),
-			cmdConfig.optionArgs(),
-			cmdConfig.libUrls(),
-			cmdConfig.inputStream(),
-			cmdConfig.charset(),
-			cmdConfig.programFilepath(),
-			cmdConfig.arguments(),
-			cmdConfig.constants(),
-			cmdConfig.jolieClassLoader(),
-			cmdConfig.isProgramCompiled(),
-			cmdConfig.typeCheck(),
-			cmdConfig.tracer(),
-			cmdConfig.tracerLevel(),
-			cmdConfig.tracerMode(),
-			cmdConfig.check(),
-			cmdConfig.printStackTraces(),
-			cmdConfig.responseTimeout(),
-			cmdConfig.logLevel(),
-			cmdConfig.programDirectory(),
-			cmdConfig.packagePaths(),
-			// difference:
-			serviceName.orElse( cmdConfig.executionTarget() ),
-			Optional.empty() );
+			cmdConfig,
+			serviceName.orElse( cmdConfig.executionTarget() ) );
 
 		interpreter = new Interpreter(
 			config,
-			currInterpreter.programDirectory(),
 			params,
 			Optional.of( currInterpreter.logPrefix() ) );
 	}
@@ -100,7 +74,7 @@ public class JolieServiceLoader extends EmbeddedServiceLoader {
 		Interpreter.Configuration configuration =
 			Interpreter.Configuration.create( currInterpreter.configuration(), new File( "#native_code_" +
 				SERVICE_LOADER_COUNTER.getAndIncrement() ), new ByteArrayInputStream( code.getBytes() ) );
-		interpreter = new Interpreter( configuration, currInterpreter.programDirectory(),
+		interpreter = new Interpreter( configuration,
 			Optional.empty(), Optional.of( currInterpreter.logPrefix() ) );
 	}
 

--- a/jolie-cli/src/main/java/jolie/Jolie.java
+++ b/jolie-cli/src/main/java/jolie/Jolie.java
@@ -80,7 +80,7 @@ public class Jolie {
 					JsUtils.parseJsonIntoValue( fileReader, params.get(), true );
 				}
 			}
-			final Interpreter interpreter = new Interpreter( config, null, params, Optional.empty() );
+			final Interpreter interpreter = new Interpreter( config, params, Optional.empty() );
 			Thread.currentThread().setContextClassLoader( interpreter.getClassLoader() );
 			Runtime.getRuntime().addShutdownHook( new Thread( () -> interpreter.exit( TERMINATION_TIMEOUT ) ) );
 			interpreter.run();

--- a/jolie-cli/src/main/java/jolie/cli/CommandLineParser.java
+++ b/jolie-cli/src/main/java/jolie/cli/CommandLineParser.java
@@ -53,7 +53,6 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 import jolie.Interpreter;
 import jolie.JolieClassLoader;
-import jolie.jap.JapURLConnection;
 import jolie.lang.Constants;
 import jolie.lang.parse.Scanner;
 import jolie.runtime.correlation.CorrelationEngine;
@@ -90,7 +89,6 @@ public class CommandLineParser implements AutoCloseable {
 	private final Level logLevel;
 	private final String executionTarget;
 	private final Optional< Path > parametersFilepath;
-	private File programDirectory = null;
 	private int cellId = 0;
 
 	/**
@@ -483,7 +481,6 @@ public class CommandLineParser implements AutoCloseable {
 									Collection< String > japOptions = parseJapManifestForOptions( manifest );
 									argsList.addAll( i + 1, japOptions );
 									japUrl = japFilename + "!";
-									programDirectory = new File( japFilename ).getParentFile();
 								}
 								break;
 							}
@@ -691,7 +688,6 @@ public class CommandLineParser implements AutoCloseable {
 		if( f.exists() ) {
 			result.stream = new FileInputStream( f );
 			result.source = f.toURI().getSchemeSpecificPart();
-			programDirectory = f.getParentFile();
 		} else {
 			for( String includePath : includePaths ) {
 				if( includePath.startsWith( "jap:" ) ) {
@@ -712,7 +708,6 @@ public class CommandLineParser implements AutoCloseable {
 						f = f.getAbsoluteFile();
 						result.stream = new FileInputStream( f );
 						result.source = f.toURI().getSchemeSpecificPart();
-						programDirectory = f.getParentFile();
 						break;
 					}
 				}
@@ -731,17 +726,6 @@ public class CommandLineParser implements AutoCloseable {
 					if( olURL != null ) {
 						result.stream = olURL.openStream();
 						result.source = olURL.toString();
-					}
-				}
-				if( programDirectory == null && olURL != null && olURL.getPath() != null ) {
-					// Try to extract the parent directory of the JAP/JAR library file
-					try {
-						File urlFile = new File( JapURLConnection.NESTING_SEPARATION_PATTERN
-							.split( new URI( olURL.getPath() ).getSchemeSpecificPart() )[ 0 ] ).getAbsoluteFile();
-						if( urlFile.exists() ) {
-							programDirectory = urlFile.getParentFile();
-						}
-					} catch( URISyntaxException e ) {
 					}
 				}
 			}
@@ -815,6 +799,7 @@ public class CommandLineParser implements AutoCloseable {
 			programStream,
 			charset,
 			programFilepath,
+			programFilepath.getParentFile(),
 			arguments,
 			constants,
 			jolieClassLoader,
@@ -827,7 +812,6 @@ public class CommandLineParser implements AutoCloseable {
 			printStackTraces,
 			responseTimeout,
 			logLevel,
-			programDirectory,
 			packagePaths,
 			executionTarget,
 			parametersFilepath );

--- a/jolie/src/main/java/jolie/runtime/embedding/JolieServiceNodeLoader.java
+++ b/jolie/src/main/java/jolie/runtime/embedding/JolieServiceNodeLoader.java
@@ -55,7 +55,6 @@ public class JolieServiceNodeLoader extends ServiceNodeLoader {
 
 			interpreter = new Interpreter(
 				configuration,
-				Paths.get( serviceNode().context().source() ).toFile(),
 				interpreter().symbolTables(),
 				builder.toProgram(),
 				v,

--- a/libjolie/src/main/java/jolie/lang/parse/module/ImportPath.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/ImportPath.java
@@ -33,6 +33,6 @@ public class ImportPath {
 
 	@Override
 	public String toString() {
-		return isRelativeImport() ? "." + String.join( ".", this.pathParts() ) : String.join( ".", this.pathParts() );
+		return String.join( ".", this.pathParts() );
 	}
 }

--- a/support/metaservice-java/src/main/java/joliex/metaservice/impl/EmbeddedMetaService.java
+++ b/support/metaservice-java/src/main/java/joliex/metaservice/impl/EmbeddedMetaService.java
@@ -106,7 +106,7 @@ public class EmbeddedMetaService extends MetaService {
 			CommandLineParser commandLineParser = new CommandLineParser(
 				buildInterpreterArguments( jolieHome, metaserviceFilepath ), this.getClass().getClassLoader(), false );
 			interpreter =
-				new Interpreter( commandLineParser.getInterpreterConfiguration(), null, Optional.empty(),
+				new Interpreter( commandLineParser.getInterpreterConfiguration(), Optional.empty(),
 					Optional.empty() );
 			startInterpreter();
 			channel = new MetaServiceChannel( this, "/" );


### PR DESCRIPTION
This PR refactors Interpreter's Configuration class and removes duplicate programDirectory from the Interpreter. It fixes the #558 and cleans up the Interpreter a bit.