### PR TITLE
Fix the ParsingContext of Services via a new wrapper for generating ParsingContexts

### DIFF
--- a/libjolie/src/main/java/jolie/lang/parse/OLParser.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParser.java
@@ -41,7 +41,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 //import jolie.lang.CodeCheckMessage;

--- a/libjolie/src/main/java/jolie/lang/parse/OLParser.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParser.java
@@ -1688,6 +1688,9 @@ public class OLParser extends AbstractParser {
 		}
 		setEndLine(); // remember end line for error
 		eat( Scanner.TokenType.RCURLY, "expected }" );
+
+		ctx = new URIParsingContext( ctx.source(), ctx.startLine(), endLine(), ctx.startColumn(), errorColumn(),
+			ctx.enclosingCode() );
 		// it is a Jolie internal service
 		if( internalIfaces != null && internalIfaces.length > 0 ) {
 			if( internalMain == null ) {


### PR DESCRIPTION
Adds a wrapper function `parseInternals` to make it easier to generate correct `ParsingContexts` when parsing.

Also refactors `parseService` to generate its `ParsingContext` using that method, fixing its previously incorrect `parsingContext`