### PR TITLE
Add location data / line numbers to faults

### DIFF
--- a/jolie/src/main/java/jolie/Interpreter.java
+++ b/jolie/src/main/java/jolie/Interpreter.java
@@ -617,10 +617,12 @@ public class Interpreter {
 		StringWriter writer = new StringWriter();
 		try {
 			new ValuePrettyPrinter( fault.value(), writer,
-				"Thrown unhandled fault: " + fault.faultName() + "\nSource location: " + fault.getContextString() + "\nContent (if any)" ).run();
+				"Thrown unhandled fault: " + fault.faultName() + "\nSource location: " + fault.getContextString()
+					+ "\nContent (if any)" ).run();
 			logInfo( writer.toString() );
 		} catch( IOException e ) {
-			logInfo( "Thrown unhandled fault: " + fault.faultName() + "\nSource location: " + fault.getContextString() );
+			logInfo(
+				"Thrown unhandled fault: " + fault.faultName() + "\nSource location: " + fault.getContextString() );
 		}
 	}
 

--- a/jolie/src/main/java/jolie/Interpreter.java
+++ b/jolie/src/main/java/jolie/Interpreter.java
@@ -617,10 +617,10 @@ public class Interpreter {
 		StringWriter writer = new StringWriter();
 		try {
 			new ValuePrettyPrinter( fault.value(), writer,
-				"Thrown unhandled fault: " + fault.faultName() + "\nContent (if any)" ).run();
+				"Thrown unhandled fault: " + fault.faultName() + "\nSource location: " + fault.getContextString() + "\nContent (if any)" ).run();
 			logInfo( writer.toString() );
 		} catch( IOException e ) {
-			logInfo( "Thrown unhandled fault: " + fault.faultName() );
+			logInfo( "Thrown unhandled fault: " + fault.faultName() + "\nSource location: " + fault.getContextString() );
 		}
 	}
 
@@ -1239,7 +1239,7 @@ public class Interpreter {
 					semanticVerifier.constantFlags(),
 					semanticVerifier.correlationFunctionInfo(),
 					initValue ))
-					.build();
+						.build();
 			}
 
 		} catch( IOException | ParserException | ClassNotFoundException | ModuleException e ) {

--- a/jolie/src/main/java/jolie/OOITBuilder.java
+++ b/jolie/src/main/java/jolie/OOITBuilder.java
@@ -913,7 +913,7 @@ public class OOITBuilder implements UnitOLVisitor {
 			n.expression().accept( this );
 			expression = currExpression;
 		}
-		currProcess = new ThrowProcess( n.id(), expression );
+		currProcess = new ThrowProcess( n.id(), expression, n.context() );
 	}
 
 	@Override
@@ -1191,7 +1191,7 @@ public class OOITBuilder implements UnitOLVisitor {
 			operands[ i++ ] = new Operand( pair.key(), currExpression );
 		}
 
-		currExpression = new ProductExpression( operands );
+		currExpression = new ProductExpression( operands, n.context() );
 	}
 
 	@Override
@@ -1241,7 +1241,7 @@ public class OOITBuilder implements UnitOLVisitor {
 	@Override
 	public void visit( PreDecrementStatement n ) {
 		PreDecrementProcess p =
-			new PreDecrementProcess( buildVariablePath( n.variablePath() ) );
+			new PreDecrementProcess( buildVariablePath( n.variablePath() ), n.context() );
 		currProcess = p;
 		currExpression = p;
 	}
@@ -1249,7 +1249,7 @@ public class OOITBuilder implements UnitOLVisitor {
 	@Override
 	public void visit( PostDecrementStatement n ) {
 		PostDecrementProcess p =
-			new PostDecrementProcess( buildVariablePath( n.variablePath() ) );
+			new PostDecrementProcess( buildVariablePath( n.variablePath() ), n.context() );
 		currProcess = p;
 		currExpression = p;
 	}
@@ -1350,7 +1350,7 @@ public class OOITBuilder implements UnitOLVisitor {
 	@Override
 	public void visit( PreIncrementStatement n ) {
 		PreIncrementProcess p =
-			new PreIncrementProcess( buildVariablePath( n.variablePath() ) );
+			new PreIncrementProcess( buildVariablePath( n.variablePath() ), n.context() );
 		currProcess = p;
 		currExpression = p;
 	}
@@ -1358,7 +1358,7 @@ public class OOITBuilder implements UnitOLVisitor {
 	@Override
 	public void visit( PostIncrementStatement n ) {
 		PostIncrementProcess p =
-			new PostIncrementProcess( buildVariablePath( n.variablePath() ) );
+			new PostIncrementProcess( buildVariablePath( n.variablePath() ), n.context() );
 		currProcess = p;
 		currExpression = p;
 	}

--- a/jolie/src/main/java/jolie/net/CommMessage.java
+++ b/jolie/src/main/java/jolie/net/CommMessage.java
@@ -162,28 +162,6 @@ public class CommMessage implements Serializable {
 	}
 
 	/**
-	 * Constructor used for cloning
-	 *
-	 * @param requestId the identifier for the request
-	 * @param operationName the operation name for this message
-	 * @param resourcePath the resource path for this message
-	 * @param value the message data to equip the message with
-	 * @param fault the fault to equip the message with
-	 * @param originalRequest the original request that this message is a response for
-	 * @param id the id number for the original CommMessage
-	 */
-	private CommMessage( long requestId, String operationName, String resourcePath, Value value, FaultException fault,
-		CommMessage originalRequest, long id ) {
-		this.requestId = requestId;
-		this.operationName = operationName;
-		this.resourcePath = resourcePath;
-		this.value = value;
-		this.fault = fault;
-		this.id = id;
-		this.originalRequest = originalRequest;
-	}
-
-	/**
 	 * Constructor
 	 *
 	 * @param requestId the identifier for the request
@@ -271,15 +249,5 @@ public class CommMessage implements Serializable {
 
 	public Optional< CommMessage > originalRequest() {
 		return Optional.ofNullable( originalRequest );
-	}
-
-	/**
-	 * For use in {@link LocalCommChannel}
-	 * 
-	 * @return a clone of the original CommMessage with only the fault being cloned
-	 */
-	public CommMessage faultClone() {
-		return new CommMessage( requestId, operationName, resourcePath, value, new FaultException( fault ),
-			originalRequest, id );
 	}
 }

--- a/jolie/src/main/java/jolie/net/CommMessage.java
+++ b/jolie/src/main/java/jolie/net/CommMessage.java
@@ -26,7 +26,6 @@ package jolie.net;
 import java.io.Serializable;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
-
 import jolie.Interpreter;
 import jolie.lang.Constants;
 import jolie.runtime.FaultException;
@@ -163,6 +162,28 @@ public class CommMessage implements Serializable {
 	}
 
 	/**
+	 * Constructor used for cloning
+	 *
+	 * @param requestId the identifier for the request
+	 * @param operationName the operation name for this message
+	 * @param resourcePath the resource path for this message
+	 * @param value the message data to equip the message with
+	 * @param fault the fault to equip the message with
+	 * @param originalRequest the original request that this message is a response for
+	 * @param id the id number for the original CommMessage
+	 */
+	private CommMessage( long requestId, String operationName, String resourcePath, Value value, FaultException fault,
+		CommMessage originalRequest, long id ) {
+		this.requestId = requestId;
+		this.operationName = operationName;
+		this.resourcePath = resourcePath;
+		this.value = value;
+		this.fault = fault;
+		this.id = id;
+		this.originalRequest = originalRequest;
+	}
+
+	/**
 	 * Constructor
 	 *
 	 * @param requestId the identifier for the request
@@ -250,5 +271,15 @@ public class CommMessage implements Serializable {
 
 	public Optional< CommMessage > originalRequest() {
 		return Optional.ofNullable( originalRequest );
+	}
+
+	/**
+	 * For use in {@link LocalCommChannel}
+	 * 
+	 * @return a clone of the original CommMessage with only the fault being cloned
+	 */
+	public CommMessage faultClone() {
+		return new CommMessage( requestId, operationName, resourcePath, value, new FaultException( fault ),
+			originalRequest, id );
 	}
 }

--- a/jolie/src/main/java/jolie/net/LocalCommChannel.java
+++ b/jolie/src/main/java/jolie/net/LocalCommChannel.java
@@ -61,13 +61,6 @@ public class LocalCommChannel extends CommChannel implements PollableCommChannel
 				throw new IOException( "Unexpected response message with id " + message.requestId() + " for operation "
 					+ message.operationName() + " in local channel" );
 			}
-			/*
-			 * if message contains a fault, then the fault needs to be cloned so the correct line numbers for
-			 * the fault is shown for both services.
-			 */
-			if( message.isFault() ) {
-				message = message.faultClone();
-			}
 			responseFut.complete( message );
 		}
 

--- a/jolie/src/main/java/jolie/net/LocalCommChannel.java
+++ b/jolie/src/main/java/jolie/net/LocalCommChannel.java
@@ -108,7 +108,13 @@ public class LocalCommChannel extends CommChannel implements PollableCommChannel
 		Interpreter interpreter = interpreter();
 		if( interpreter == null ) {
 			throw new IOException( "Sending Channel is closed" );
-		} else {
+		} else { /*
+					 * TODO: Handle Faults Context: if message contains a fault, remove its context? (remove or create
+					 * copy without?) (local channels are the only channel to also "send" the context) (could also
+					 * ignore, as the reciever should add its own context -> can/will give race conditions if not
+					 * cloned) Must create clone to not get wrong error lines for a Locally embeded service! Or must
+					 * make sure Fault is reported before sent!
+					 */
 			CompletableFuture< CommMessage > f = new CompletableFuture<>();
 			responseWaiters.put( message.requestId(), f );
 			interpreter.commCore().scheduleReceive( new CoLocalCommChannel( message, f ), listener.inputPort() );

--- a/jolie/src/main/java/jolie/process/PostDecrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PostDecrementProcess.java
@@ -65,8 +65,8 @@ public class PostDecrementProcess implements Process, Expression {
 			} else if( o instanceof Long ) {
 				val.setValue( ((Long) o).longValue() - 1 );
 			} else {
-				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-					.withContext( this.context );
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double.",
+					this.context );
 			}
 		}
 	}
@@ -84,8 +84,8 @@ public class PostDecrementProcess implements Process, Expression {
 		} else if( o instanceof Long ) {
 			val.setValue( ((Long) o).longValue() - 1 );
 		} else {
-			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-				.withContext( this.context )
+			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double.",
+				this.context )
 				.toRuntimeFaultException();
 		}
 		return orig;

--- a/jolie/src/main/java/jolie/process/PostDecrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PostDecrementProcess.java
@@ -23,6 +23,7 @@ package jolie.process;
 
 import jolie.ExecutionThread;
 import jolie.lang.Constants;
+import jolie.lang.parse.context.ParsingContext;
 import jolie.runtime.FaultException;
 import jolie.runtime.Value;
 import jolie.runtime.VariablePath;
@@ -30,19 +31,21 @@ import jolie.runtime.expression.Expression;
 
 public class PostDecrementProcess implements Process, Expression {
 	final private VariablePath path;
+	final private ParsingContext context;
 
-	public PostDecrementProcess( VariablePath varPath ) {
+	public PostDecrementProcess( VariablePath varPath, ParsingContext context ) {
 		this.path = varPath;
+		this.context = context;
 	}
 
 	@Override
 	public Process copy( TransformationReason reason ) {
-		return new PostDecrementProcess( (VariablePath) path.cloneExpression( reason ) );
+		return new PostDecrementProcess( (VariablePath) path.cloneExpression( reason ), context );
 	}
 
 	@Override
 	public Expression cloneExpression( TransformationReason reason ) {
-		return new PostDecrementProcess( (VariablePath) path.cloneExpression( reason ) );
+		return new PostDecrementProcess( (VariablePath) path.cloneExpression( reason ), context );
 	}
 
 	@Override
@@ -62,7 +65,8 @@ public class PostDecrementProcess implements Process, Expression {
 			} else if( o instanceof Long ) {
 				val.setValue( ((Long) o).longValue() - 1 );
 			} else {
-				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." );
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
+					.addContext( this.context );
 			}
 		}
 	}
@@ -81,6 +85,7 @@ public class PostDecrementProcess implements Process, Expression {
 			val.setValue( ((Long) o).longValue() - 1 );
 		} else {
 			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
+				.addContext( this.context )
 				.toRuntimeFaultException();
 		}
 		return orig;

--- a/jolie/src/main/java/jolie/process/PostDecrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PostDecrementProcess.java
@@ -66,7 +66,7 @@ public class PostDecrementProcess implements Process, Expression {
 				val.setValue( ((Long) o).longValue() - 1 );
 			} else {
 				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-					.addContext( this.context );
+					.withContext( this.context );
 			}
 		}
 	}
@@ -85,7 +85,7 @@ public class PostDecrementProcess implements Process, Expression {
 			val.setValue( ((Long) o).longValue() - 1 );
 		} else {
 			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-				.addContext( this.context )
+				.withContext( this.context )
 				.toRuntimeFaultException();
 		}
 		return orig;

--- a/jolie/src/main/java/jolie/process/PostIncrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PostIncrementProcess.java
@@ -63,8 +63,8 @@ public class PostIncrementProcess implements Process, Expression {
 			} else if( o instanceof Long ) {
 				val.setValue( ((Long) o).longValue() + 1 );
 			} else {
-				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-					.withContext( this.context );
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double.",
+					this.context );
 			}
 		}
 	}
@@ -88,8 +88,8 @@ public class PostIncrementProcess implements Process, Expression {
 				orig = Value.create( ((Long) o).longValue() );
 				val.setValue( ((Long) o).longValue() + 1 );
 			} else {
-				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-					.withContext( this.context )
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double.",
+					this.context )
 					.toRuntimeFaultException();
 			}
 		}

--- a/jolie/src/main/java/jolie/process/PostIncrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PostIncrementProcess.java
@@ -21,6 +21,7 @@ package jolie.process;
 
 import jolie.ExecutionThread;
 import jolie.lang.Constants;
+import jolie.lang.parse.context.ParsingContext;
 import jolie.runtime.FaultException;
 import jolie.runtime.Value;
 import jolie.runtime.VariablePath;
@@ -28,19 +29,21 @@ import jolie.runtime.expression.Expression;
 
 public class PostIncrementProcess implements Process, Expression {
 	private final VariablePath path;
+	private final ParsingContext context;
 
-	public PostIncrementProcess( VariablePath varPath ) {
+	public PostIncrementProcess( VariablePath varPath, ParsingContext context ) {
 		this.path = varPath;
+		this.context = context;
 	}
 
 	@Override
 	public Process copy( TransformationReason reason ) {
-		return new PostIncrementProcess( (VariablePath) path.cloneExpression( reason ) );
+		return new PostIncrementProcess( (VariablePath) path.cloneExpression( reason ), context );
 	}
 
 	@Override
 	public Expression cloneExpression( TransformationReason reason ) {
-		return new PostIncrementProcess( (VariablePath) path.cloneExpression( reason ) );
+		return new PostIncrementProcess( (VariablePath) path.cloneExpression( reason ), context );
 	}
 
 	@Override
@@ -60,7 +63,8 @@ public class PostIncrementProcess implements Process, Expression {
 			} else if( o instanceof Long ) {
 				val.setValue( ((Long) o).longValue() + 1 );
 			} else {
-				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." );
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
+					.addContext( this.context );
 			}
 		}
 	}
@@ -85,6 +89,7 @@ public class PostIncrementProcess implements Process, Expression {
 				val.setValue( ((Long) o).longValue() + 1 );
 			} else {
 				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
+					.addContext( this.context )
 					.toRuntimeFaultException();
 			}
 		}

--- a/jolie/src/main/java/jolie/process/PostIncrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PostIncrementProcess.java
@@ -64,7 +64,7 @@ public class PostIncrementProcess implements Process, Expression {
 				val.setValue( ((Long) o).longValue() + 1 );
 			} else {
 				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-					.addContext( this.context );
+					.withContext( this.context );
 			}
 		}
 	}
@@ -89,7 +89,7 @@ public class PostIncrementProcess implements Process, Expression {
 				val.setValue( ((Long) o).longValue() + 1 );
 			} else {
 				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-					.addContext( this.context )
+					.withContext( this.context )
 					.toRuntimeFaultException();
 			}
 		}

--- a/jolie/src/main/java/jolie/process/PreDecrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PreDecrementProcess.java
@@ -66,7 +66,7 @@ public class PreDecrementProcess implements Process, Expression {
 				val.setValue( ((Long) o).longValue() - 1 );
 			} else {
 				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-					.addContext( this.context );
+					.withContext( this.context );
 			}
 		}
 	}
@@ -86,7 +86,7 @@ public class PreDecrementProcess implements Process, Expression {
 				val.setValue( ((Long) o).longValue() - 1 );
 			} else {
 				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-					.addContext( this.context )
+					.withContext( this.context )
 					.toRuntimeFaultException();
 			}
 		}

--- a/jolie/src/main/java/jolie/process/PreDecrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PreDecrementProcess.java
@@ -65,8 +65,8 @@ public class PreDecrementProcess implements Process, Expression {
 			} else if( o instanceof Long ) {
 				val.setValue( ((Long) o).longValue() - 1 );
 			} else {
-				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-					.withContext( this.context );
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double.",
+					this.context );
 			}
 		}
 	}
@@ -85,8 +85,8 @@ public class PreDecrementProcess implements Process, Expression {
 			} else if( o instanceof Long ) {
 				val.setValue( ((Long) o).longValue() - 1 );
 			} else {
-				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-					.withContext( this.context )
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double.",
+					this.context )
 					.toRuntimeFaultException();
 			}
 		}

--- a/jolie/src/main/java/jolie/process/PreDecrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PreDecrementProcess.java
@@ -23,6 +23,7 @@ package jolie.process;
 
 import jolie.ExecutionThread;
 import jolie.lang.Constants;
+import jolie.lang.parse.context.ParsingContext;
 import jolie.runtime.FaultException;
 import jolie.runtime.Value;
 import jolie.runtime.VariablePath;
@@ -30,19 +31,21 @@ import jolie.runtime.expression.Expression;
 
 public class PreDecrementProcess implements Process, Expression {
 	final private VariablePath path;
+	final private ParsingContext context;
 
-	public PreDecrementProcess( VariablePath varPath ) {
+	public PreDecrementProcess( VariablePath varPath, ParsingContext context ) {
 		this.path = varPath;
+		this.context = context;
 	}
 
 	@Override
 	public Process copy( TransformationReason reason ) {
-		return new PreDecrementProcess( (VariablePath) path.cloneExpression( reason ) );
+		return new PreDecrementProcess( (VariablePath) path.cloneExpression( reason ), context );
 	}
 
 	@Override
 	public Expression cloneExpression( TransformationReason reason ) {
-		return new PreDecrementProcess( (VariablePath) path.cloneExpression( reason ) );
+		return new PreDecrementProcess( (VariablePath) path.cloneExpression( reason ), context );
 	}
 
 	@Override
@@ -62,7 +65,8 @@ public class PreDecrementProcess implements Process, Expression {
 			} else if( o instanceof Long ) {
 				val.setValue( ((Long) o).longValue() - 1 );
 			} else {
-				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." );
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
+					.addContext( this.context );
 			}
 		}
 	}
@@ -82,6 +86,7 @@ public class PreDecrementProcess implements Process, Expression {
 				val.setValue( ((Long) o).longValue() - 1 );
 			} else {
 				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
+					.addContext( this.context )
 					.toRuntimeFaultException();
 			}
 		}

--- a/jolie/src/main/java/jolie/process/PreIncrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PreIncrementProcess.java
@@ -21,6 +21,7 @@ package jolie.process;
 
 import jolie.ExecutionThread;
 import jolie.lang.Constants;
+import jolie.lang.parse.context.ParsingContext;
 import jolie.runtime.FaultException;
 import jolie.runtime.Value;
 import jolie.runtime.VariablePath;
@@ -28,19 +29,21 @@ import jolie.runtime.expression.Expression;
 
 public class PreIncrementProcess implements Process, Expression {
 	private final VariablePath path;
+	private final ParsingContext context;
 
-	public PreIncrementProcess( VariablePath varPath ) {
+	public PreIncrementProcess( VariablePath varPath, ParsingContext context ) {
 		this.path = varPath;
+		this.context = context;
 	}
 
 	@Override
 	public Process copy( TransformationReason reason ) {
-		return new PreIncrementProcess( (VariablePath) path.cloneExpression( reason ) );
+		return new PreIncrementProcess( (VariablePath) path.cloneExpression( reason ), context );
 	}
 
 	@Override
 	public Expression cloneExpression( TransformationReason reason ) {
-		return new PreIncrementProcess( (VariablePath) path.cloneExpression( reason ) );
+		return new PreIncrementProcess( (VariablePath) path.cloneExpression( reason ), context );
 	}
 
 	@Override
@@ -60,7 +63,8 @@ public class PreIncrementProcess implements Process, Expression {
 			} else if( o instanceof Long ) {
 				val.setValue( ((Long) o).longValue() + 1 );
 			} else {
-				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." );
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
+					.addContext( this.context );
 			}
 		}
 	}
@@ -80,6 +84,7 @@ public class PreIncrementProcess implements Process, Expression {
 				val.setValue( ((Long) o).longValue() + 1 );
 			} else {
 				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
+					.addContext( this.context )
 					.toRuntimeFaultException();
 			}
 		}

--- a/jolie/src/main/java/jolie/process/PreIncrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PreIncrementProcess.java
@@ -64,7 +64,7 @@ public class PreIncrementProcess implements Process, Expression {
 				val.setValue( ((Long) o).longValue() + 1 );
 			} else {
 				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-					.addContext( this.context );
+					.withContext( this.context );
 			}
 		}
 	}
@@ -84,7 +84,7 @@ public class PreIncrementProcess implements Process, Expression {
 				val.setValue( ((Long) o).longValue() + 1 );
 			} else {
 				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-					.addContext( this.context )
+					.withContext( this.context )
 					.toRuntimeFaultException();
 			}
 		}

--- a/jolie/src/main/java/jolie/process/PreIncrementProcess.java
+++ b/jolie/src/main/java/jolie/process/PreIncrementProcess.java
@@ -63,8 +63,8 @@ public class PreIncrementProcess implements Process, Expression {
 			} else if( o instanceof Long ) {
 				val.setValue( ((Long) o).longValue() + 1 );
 			} else {
-				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-					.withContext( this.context );
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double.",
+					this.context );
 			}
 		}
 	}
@@ -83,8 +83,8 @@ public class PreIncrementProcess implements Process, Expression {
 			} else if( o instanceof Long ) {
 				val.setValue( ((Long) o).longValue() + 1 );
 			} else {
-				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double." )
-					.withContext( this.context )
+				throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "expected type int, long, or double.",
+					this.context )
 					.toRuntimeFaultException();
 			}
 		}

--- a/jolie/src/main/java/jolie/process/RequestResponseProcess.java
+++ b/jolie/src/main/java/jolie/process/RequestResponseProcess.java
@@ -224,7 +224,8 @@ public class RequestResponseProcess implements InputOperationProcess {
 							log( "TYPE MISMATCH", response );
 							typeMismatch = new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 								"Request-Response input operation output value TypeMismatch (operation "
-									+ operation.id() + "): " + e.getMessage() ).withContext( this.context );
+									+ operation.id() + "): " + e.getMessage(),
+								this.context );
 							response = CommMessage.createFaultResponse( message, new FaultException(
 								Constants.TYPE_MISMATCH_FAULT_NAME, "Internal server error (TypeMismatch)" ) );
 							// Context not added as it should not & cannot be sent
@@ -244,7 +245,8 @@ public class RequestResponseProcess implements InputOperationProcess {
 			} catch( TypeCheckingException e ) {
 				typeMismatch = new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 					"Request-Response process TypeMismatch for fault " + f.faultName() + " (operation " + operation.id()
-						+ "): " + e.getMessage() ).withContext( this.context );
+						+ "): " + e.getMessage(),
+					this.context );
 				response = CommMessage.createFaultResponse( message, typeMismatch );
 				responseStatus = OperationEndedEvent.ERROR;
 				details = typeMismatch.faultName();
@@ -270,7 +272,7 @@ public class RequestResponseProcess implements InputOperationProcess {
 			}
 		} catch( IOException e ) {
 			// Interpreter.getInstance().logSevere( e );
-			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e ).withContext( this.context );
+			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e, this.context );
 		} finally {
 			try {
 				channel.release(); // TODO: what if the channel is in disposeForInput?

--- a/jolie/src/main/java/jolie/process/RequestResponseProcess.java
+++ b/jolie/src/main/java/jolie/process/RequestResponseProcess.java
@@ -224,7 +224,7 @@ public class RequestResponseProcess implements InputOperationProcess {
 							log( "TYPE MISMATCH", response );
 							typeMismatch = new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 								"Request-Response input operation output value TypeMismatch (operation "
-									+ operation.id() + "): " + e.getMessage() ).addContext( this.context );
+									+ operation.id() + "): " + e.getMessage() ).withContext( this.context );
 							response = CommMessage.createFaultResponse( message, new FaultException(
 								Constants.TYPE_MISMATCH_FAULT_NAME, "Internal server error (TypeMismatch)" ) );
 							// Context not added as it should not & cannot be sent
@@ -244,7 +244,7 @@ public class RequestResponseProcess implements InputOperationProcess {
 			} catch( TypeCheckingException e ) {
 				typeMismatch = new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 					"Request-Response process TypeMismatch for fault " + f.faultName() + " (operation " + operation.id()
-						+ "): " + e.getMessage() ).addContext( this.context );
+						+ "): " + e.getMessage() ).withContext( this.context );
 				response = CommMessage.createFaultResponse( message, typeMismatch );
 				responseStatus = OperationEndedEvent.ERROR;
 				details = typeMismatch.faultName();
@@ -270,7 +270,7 @@ public class RequestResponseProcess implements InputOperationProcess {
 			}
 		} catch( IOException e ) {
 			// Interpreter.getInstance().logSevere( e );
-			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e ).addContext( this.context );
+			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e ).withContext( this.context );
 		} finally {
 			try {
 				channel.release(); // TODO: what if the channel is in disposeForInput?

--- a/jolie/src/main/java/jolie/process/RequestResponseProcess.java
+++ b/jolie/src/main/java/jolie/process/RequestResponseProcess.java
@@ -224,8 +224,7 @@ public class RequestResponseProcess implements InputOperationProcess {
 							log( "TYPE MISMATCH", response );
 							typeMismatch = new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 								"Request-Response input operation output value TypeMismatch (operation "
-									+ operation.id() + "): " + e.getMessage() );
-							// TODO context should be added to message
+									+ operation.id() + "): " + e.getMessage() ).addContext( this.context );
 							response = CommMessage.createFaultResponse( message, new FaultException(
 								Constants.TYPE_MISMATCH_FAULT_NAME, "Internal server error (TypeMismatch)" ) );
 							// Context not added as it should not & cannot be sent
@@ -245,9 +244,8 @@ public class RequestResponseProcess implements InputOperationProcess {
 			} catch( TypeCheckingException e ) {
 				typeMismatch = new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 					"Request-Response process TypeMismatch for fault " + f.faultName() + " (operation " + operation.id()
-						+ "): " + e.getMessage() ); // TODO context should be added to message
+						+ "): " + e.getMessage() ).addContext( this.context );
 				response = CommMessage.createFaultResponse( message, typeMismatch );
-				// Context not added as it should not & cannot be sent
 				responseStatus = OperationEndedEvent.ERROR;
 				details = typeMismatch.faultName();
 			}

--- a/jolie/src/main/java/jolie/process/RequestResponseProcess.java
+++ b/jolie/src/main/java/jolie/process/RequestResponseProcess.java
@@ -225,7 +225,7 @@ public class RequestResponseProcess implements InputOperationProcess {
 							typeMismatch = new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 								"Request-Response input operation output value TypeMismatch (operation "
 									+ operation.id() + "): " + e.getMessage() );
-									// TODO context should be added to message
+							// TODO context should be added to message
 							response = CommMessage.createFaultResponse( message, new FaultException(
 								Constants.TYPE_MISMATCH_FAULT_NAME, "Internal server error (TypeMismatch)" ) );
 							// Context not added as it should not & cannot be sent

--- a/jolie/src/main/java/jolie/process/RequestResponseProcess.java
+++ b/jolie/src/main/java/jolie/process/RequestResponseProcess.java
@@ -23,7 +23,6 @@ package jolie.process;
 
 import java.io.IOException;
 import java.util.concurrent.Future;
-
 import jolie.ExecutionThread;
 import jolie.Interpreter;
 import jolie.lang.Constants;
@@ -175,7 +174,9 @@ public class RequestResponseProcess implements InputOperationProcess {
 			Interpreter.getInstance().logSevere(
 				"Request-Response process for " + operation.id() +
 					" threw an undeclared fault for that operation (" + f.faultName() + "), throwing TypeMismatch" );
+			// TODO context should be added to message
 			f = new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "Internal server error" );
+			// Context not added as it should not & cannot be sent
 		}
 		return CommMessage.createFaultResponse( request, f );
 	}
@@ -224,8 +225,10 @@ public class RequestResponseProcess implements InputOperationProcess {
 							typeMismatch = new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 								"Request-Response input operation output value TypeMismatch (operation "
 									+ operation.id() + "): " + e.getMessage() );
+									// TODO context should be added to message
 							response = CommMessage.createFaultResponse( message, new FaultException(
 								Constants.TYPE_MISMATCH_FAULT_NAME, "Internal server error (TypeMismatch)" ) );
+							// Context not added as it should not & cannot be sent
 							responseStatus = OperationEndedEvent.ERROR;
 							details = Constants.TYPE_MISMATCH_FAULT_NAME;
 						}
@@ -242,8 +245,9 @@ public class RequestResponseProcess implements InputOperationProcess {
 			} catch( TypeCheckingException e ) {
 				typeMismatch = new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 					"Request-Response process TypeMismatch for fault " + f.faultName() + " (operation " + operation.id()
-						+ "): " + e.getMessage() );
+						+ "): " + e.getMessage() ); // TODO context should be added to message
 				response = CommMessage.createFaultResponse( message, typeMismatch );
+				// Context not added as it should not & cannot be sent
 				responseStatus = OperationEndedEvent.ERROR;
 				details = typeMismatch.faultName();
 			}
@@ -268,7 +272,7 @@ public class RequestResponseProcess implements InputOperationProcess {
 			}
 		} catch( IOException e ) {
 			// Interpreter.getInstance().logSevere( e );
-			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e );
+			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e ).addContext( this.context );
 		} finally {
 			try {
 				channel.release(); // TODO: what if the channel is in disposeForInput?

--- a/jolie/src/main/java/jolie/process/ScopeProcess.java
+++ b/jolie/src/main/java/jolie/process/ScopeProcess.java
@@ -88,7 +88,7 @@ public class ScopeProcess implements Process {
 			} catch( ExitingException e ) {
 				throw e;
 			} catch( Exception e ) {
-				fault = new FaultException( e );
+				fault = new FaultException( e ); // TODO find and add context?
 			}
 		}
 	}

--- a/jolie/src/main/java/jolie/process/ThrowProcess.java
+++ b/jolie/src/main/java/jolie/process/ThrowProcess.java
@@ -22,6 +22,7 @@
 package jolie.process;
 
 import jolie.ExecutionThread;
+import jolie.lang.parse.context.ParsingContext;
 import jolie.runtime.FaultException;
 import jolie.runtime.expression.Expression;
 
@@ -29,27 +30,33 @@ import jolie.runtime.expression.Expression;
 public class ThrowProcess implements Process {
 	final private String faultName;
 	final private Expression expression;
+	final private ParsingContext context;
 
-	public ThrowProcess( String faultName, Expression expression ) {
+	public ThrowProcess( String faultName, Expression expression, ParsingContext context ) {
 		this.faultName = faultName;
 		this.expression = expression;
+		this.context = context;
 	}
 
 	@Override
 	public Process copy( TransformationReason reason ) {
-		return new ThrowProcess( faultName, expression );
+		return new ThrowProcess( faultName, expression, context );
 	}
 
 	@Override
 	public void run()
-		throws FaultException {
+		throws FaultException.RuntimeFaultException {
 		if( ExecutionThread.currentThread().isKilled() )
 			return;
 
 		if( expression == null ) {
-			throw new FaultException( faultName );
+			throw new FaultException( faultName )
+				.addContext( this.context )
+				.toRuntimeFaultException();
 		} else {
-			throw new FaultException( faultName, expression.evaluate() );
+			throw new FaultException( faultName, expression.evaluate() )
+				.addContext( this.context )
+				.toRuntimeFaultException();
 		}
 	}
 

--- a/jolie/src/main/java/jolie/process/ThrowProcess.java
+++ b/jolie/src/main/java/jolie/process/ThrowProcess.java
@@ -51,10 +51,10 @@ public class ThrowProcess implements Process {
 
 		if( expression == null ) {
 			throw new FaultException( faultName )
-				.addContext( this.context );
+				.withContext( this.context );
 		} else {
 			throw new FaultException( faultName, expression.evaluate() )
-				.addContext( this.context );
+				.withContext( this.context );
 		}
 	}
 

--- a/jolie/src/main/java/jolie/process/ThrowProcess.java
+++ b/jolie/src/main/java/jolie/process/ThrowProcess.java
@@ -50,11 +50,9 @@ public class ThrowProcess implements Process {
 			return;
 
 		if( expression == null ) {
-			throw new FaultException( faultName )
-				.withContext( this.context );
+			throw new FaultException( faultName, this.context );
 		} else {
-			throw new FaultException( faultName, expression.evaluate() )
-				.withContext( this.context );
+			throw new FaultException( faultName, expression.evaluate(), this.context );
 		}
 	}
 

--- a/jolie/src/main/java/jolie/process/ThrowProcess.java
+++ b/jolie/src/main/java/jolie/process/ThrowProcess.java
@@ -45,18 +45,16 @@ public class ThrowProcess implements Process {
 
 	@Override
 	public void run()
-		throws FaultException.RuntimeFaultException {
+		throws FaultException {
 		if( ExecutionThread.currentThread().isKilled() )
 			return;
 
 		if( expression == null ) {
 			throw new FaultException( faultName )
-				.addContext( this.context )
-				.toRuntimeFaultException();
+				.addContext( this.context );
 		} else {
 			throw new FaultException( faultName, expression.evaluate() )
-				.addContext( this.context )
-				.toRuntimeFaultException();
+				.addContext( this.context );
 		}
 	}
 

--- a/jolie/src/main/java/jolie/process/courier/ForwardNotificationProcess.java
+++ b/jolie/src/main/java/jolie/process/courier/ForwardNotificationProcess.java
@@ -135,14 +135,12 @@ public class ForwardNotificationProcess implements Process {
 				}
 			}
 		} catch( IOException e ) {
-			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e )
-				.withContext( this.context );
+			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e, this.context );
 		} catch( URISyntaxException e ) {
 			Interpreter.getInstance().logSevere( e );
 		} catch( TypeCheckingException e ) {
 			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
-				"TypeMismatch (" + operationName + "@" + outputPort.id() + "): " + e.getMessage() )
-					.withContext( this.context );
+				"TypeMismatch (" + operationName + "@" + outputPort.id() + "): " + e.getMessage(), this.context );
 		} finally {
 			if( channel != null ) {
 				try {

--- a/jolie/src/main/java/jolie/process/courier/ForwardNotificationProcess.java
+++ b/jolie/src/main/java/jolie/process/courier/ForwardNotificationProcess.java
@@ -136,13 +136,13 @@ public class ForwardNotificationProcess implements Process {
 			}
 		} catch( IOException e ) {
 			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e )
-				.addContext( this.context );
+				.withContext( this.context );
 		} catch( URISyntaxException e ) {
 			Interpreter.getInstance().logSevere( e );
 		} catch( TypeCheckingException e ) {
 			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 				"TypeMismatch (" + operationName + "@" + outputPort.id() + "): " + e.getMessage() )
-				.addContext( this.context );
+					.withContext( this.context );
 		} finally {
 			if( channel != null ) {
 				try {

--- a/jolie/src/main/java/jolie/process/courier/ForwardNotificationProcess.java
+++ b/jolie/src/main/java/jolie/process/courier/ForwardNotificationProcess.java
@@ -24,7 +24,6 @@ package jolie.process.courier;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.concurrent.ExecutionException;
-
 import jolie.ExecutionThread;
 import jolie.Interpreter;
 import jolie.lang.Constants;
@@ -136,12 +135,14 @@ public class ForwardNotificationProcess implements Process {
 				}
 			}
 		} catch( IOException e ) {
-			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e );
+			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e )
+				.addContext( this.context );
 		} catch( URISyntaxException e ) {
 			Interpreter.getInstance().logSevere( e );
 		} catch( TypeCheckingException e ) {
 			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
-				"TypeMismatch (" + operationName + "@" + outputPort.id() + "): " + e.getMessage() );
+				"TypeMismatch (" + operationName + "@" + outputPort.id() + "): " + e.getMessage() )
+				.addContext( this.context );
 		} finally {
 			if( channel != null ) {
 				try {

--- a/jolie/src/main/java/jolie/process/courier/ForwardSolicitResponseProcess.java
+++ b/jolie/src/main/java/jolie/process/courier/ForwardSolicitResponseProcess.java
@@ -139,10 +139,10 @@ public class ForwardSolicitResponseProcess implements Process {
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 							"Received fault " + response.fault().faultName() + " TypeMismatch (" + operationName + "@"
 								+ outputPort.id() + "): " + e.getMessage() )
-							.addContext( this.context );
+									.addContext( this.context );
 					}
 				}
-				throw response.fault();
+				throw response.fault().addContext( this.context );
 			} else {
 				if( aggregatedTypeDescription.responseType() != null ) {
 					try {
@@ -150,7 +150,7 @@ public class ForwardSolicitResponseProcess implements Process {
 					} catch( TypeCheckingException e ) {
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "Received message TypeMismatch ("
 							+ operationName + "@" + outputPort.id() + "): " + e.getMessage() )
-							.addContext( this.context );
+								.addContext( this.context );
 					}
 				}
 			}
@@ -166,7 +166,7 @@ public class ForwardSolicitResponseProcess implements Process {
 		} catch( TypeCheckingException e ) {
 			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 				"Output message TypeMismatch (" + operationName + "@" + outputPort.id() + "): " + e.getMessage() )
-				.addContext( this.context );
+					.addContext( this.context );
 		} finally {
 			if( channel != null ) {
 				try {

--- a/jolie/src/main/java/jolie/process/courier/ForwardSolicitResponseProcess.java
+++ b/jolie/src/main/java/jolie/process/courier/ForwardSolicitResponseProcess.java
@@ -139,10 +139,10 @@ public class ForwardSolicitResponseProcess implements Process {
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 							"Received fault " + response.fault().faultName() + " TypeMismatch (" + operationName + "@"
 								+ outputPort.id() + "): " + e.getMessage() )
-									.addContext( this.context );
+									.withContext( this.context );
 					}
 				}
-				throw response.fault().addContext( this.context );
+				throw response.fault().withContext( this.context );
 			} else {
 				if( aggregatedTypeDescription.responseType() != null ) {
 					try {
@@ -150,7 +150,7 @@ public class ForwardSolicitResponseProcess implements Process {
 					} catch( TypeCheckingException e ) {
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "Received message TypeMismatch ("
 							+ operationName + "@" + outputPort.id() + "): " + e.getMessage() )
-								.addContext( this.context );
+								.withContext( this.context );
 					}
 				}
 			}
@@ -160,13 +160,13 @@ public class ForwardSolicitResponseProcess implements Process {
 			 */
 		} catch( IOException e ) {
 			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e )
-				.addContext( this.context );
+				.withContext( this.context );
 		} catch( URISyntaxException e ) {
 			Interpreter.getInstance().logSevere( e );
 		} catch( TypeCheckingException e ) {
 			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 				"Output message TypeMismatch (" + operationName + "@" + outputPort.id() + "): " + e.getMessage() )
-					.addContext( this.context );
+					.withContext( this.context );
 		} finally {
 			if( channel != null ) {
 				try {

--- a/jolie/src/main/java/jolie/process/courier/ForwardSolicitResponseProcess.java
+++ b/jolie/src/main/java/jolie/process/courier/ForwardSolicitResponseProcess.java
@@ -138,8 +138,8 @@ public class ForwardSolicitResponseProcess implements Process {
 					} catch( TypeCheckingException e ) {
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 							"Received fault " + response.fault().faultName() + " TypeMismatch (" + operationName + "@"
-								+ outputPort.id() + "): " + e.getMessage() )
-									.withContext( this.context );
+								+ outputPort.id() + "): " + e.getMessage(),
+							this.context );
 					}
 				}
 				throw response.fault().withContext( this.context );
@@ -149,8 +149,7 @@ public class ForwardSolicitResponseProcess implements Process {
 						aggregatedTypeDescription.responseType().check( response.value() );
 					} catch( TypeCheckingException e ) {
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "Received message TypeMismatch ("
-							+ operationName + "@" + outputPort.id() + "): " + e.getMessage() )
-								.withContext( this.context );
+							+ operationName + "@" + outputPort.id() + "): " + e.getMessage(), this.context );
 					}
 				}
 			}
@@ -159,14 +158,13 @@ public class ForwardSolicitResponseProcess implements Process {
 			 * try { installProcess.run(); } catch( ExitingException e ) { assert false; }
 			 */
 		} catch( IOException e ) {
-			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e )
-				.withContext( this.context );
+			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e, this.context );
 		} catch( URISyntaxException e ) {
 			Interpreter.getInstance().logSevere( e );
 		} catch( TypeCheckingException e ) {
 			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
-				"Output message TypeMismatch (" + operationName + "@" + outputPort.id() + "): " + e.getMessage() )
-					.withContext( this.context );
+				"Output message TypeMismatch (" + operationName + "@" + outputPort.id() + "): " + e.getMessage(),
+				this.context );
 		} finally {
 			if( channel != null ) {
 				try {

--- a/jolie/src/main/java/jolie/process/courier/ForwardSolicitResponseProcess.java
+++ b/jolie/src/main/java/jolie/process/courier/ForwardSolicitResponseProcess.java
@@ -24,7 +24,6 @@ package jolie.process.courier;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.concurrent.ExecutionException;
-
 import jolie.ExecutionThread;
 import jolie.Interpreter;
 import jolie.lang.Constants;
@@ -139,7 +138,8 @@ public class ForwardSolicitResponseProcess implements Process {
 					} catch( TypeCheckingException e ) {
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 							"Received fault " + response.fault().faultName() + " TypeMismatch (" + operationName + "@"
-								+ outputPort.id() + "): " + e.getMessage() );
+								+ outputPort.id() + "): " + e.getMessage() )
+							.addContext( this.context );
 					}
 				}
 				throw response.fault();
@@ -149,7 +149,8 @@ public class ForwardSolicitResponseProcess implements Process {
 						aggregatedTypeDescription.responseType().check( response.value() );
 					} catch( TypeCheckingException e ) {
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "Received message TypeMismatch ("
-							+ operationName + "@" + outputPort.id() + "): " + e.getMessage() );
+							+ operationName + "@" + outputPort.id() + "): " + e.getMessage() )
+							.addContext( this.context );
 					}
 				}
 			}
@@ -158,12 +159,14 @@ public class ForwardSolicitResponseProcess implements Process {
 			 * try { installProcess.run(); } catch( ExitingException e ) { assert false; }
 			 */
 		} catch( IOException e ) {
-			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e );
+			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e )
+				.addContext( this.context );
 		} catch( URISyntaxException e ) {
 			Interpreter.getInstance().logSevere( e );
 		} catch( TypeCheckingException e ) {
 			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
-				"Output message TypeMismatch (" + operationName + "@" + outputPort.id() + "): " + e.getMessage() );
+				"Output message TypeMismatch (" + operationName + "@" + outputPort.id() + "): " + e.getMessage() )
+				.addContext( this.context );
 		} finally {
 			if( channel != null ) {
 				try {

--- a/jolie/src/main/java/jolie/runtime/FaultException.java
+++ b/jolie/src/main/java/jolie/runtime/FaultException.java
@@ -63,6 +63,17 @@ public class FaultException extends Exception {
 	}
 
 	/**
+	 * Constructor for cloning FaultException, removing contexts but keeping stacktace.
+	 *
+	 * @param f the FaultException to clone.
+	 */
+	public FaultException( FaultException f ) {
+		super( f );
+		this.faultName = f.faultName;
+		this.value = f.value;
+	}
+
+	/**
 	 * Constructor. Shortcut for {@code FaultException( faultName, Value.create( message ) )}
 	 *
 	 * @param faultName
@@ -83,6 +94,8 @@ public class FaultException extends Exception {
 		this.faultName = faultName;
 		this.value = value;
 	}
+
+
 
 	/**
 	 * Constructor. Shortcut for {@code FaultException( faultName, Value.create() )}
@@ -142,7 +155,12 @@ public class FaultException extends Exception {
 	 *         added.
 	 */
 	public String getContextString() {
-		return context != null ? context.sourceName() + ":" + context.startLine() : "Context not present";
+		return context != null
+			? new StringBuilder( context.sourceName() )
+				.append( ":" )
+				.append( context.startLine() )
+				.toString()
+			: "Context not present";
 	}
 
 	// A RuntimeFaultException is used for runtime errors from which it is

--- a/jolie/src/main/java/jolie/runtime/FaultException.java
+++ b/jolie/src/main/java/jolie/runtime/FaultException.java
@@ -38,16 +38,32 @@ public class FaultException extends Exception {
 	private final ParsingContext context;
 
 	/**
-	 * Constructor. This constructor behaves as
-	 * {@code FaultException( faultName, Value.create( t.getMessage() ) )}, but it also adds a
+	 * Constructor. Shortcut for {@code FaultException( faultNmae, t, context )}.
+	 *
+	 * This constructor behaves as {@code FaultException( faultName, Value.create( t.getMessage() ) )},
+	 * but it also adds a {@code stackTrace} subnode to the value of this fault containing the stack
+	 * trace of the passed {@link Throwable} t.
+	 *
+	 * @param faultName the name of the fault
+	 * @param t the {@link Throwable} whose message and stack trace should be read
+	 */
+	public FaultException( String faultName, Throwable t ) {
+		this( faultName, t, null );
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * This constructor behaves as
+	 * {@code FaultException( faultName, Value.create( t.getMessage() ), context )}, but it also adds a
 	 * {@code stackTrace} subnode to the value of this fault containing the stack trace of the passed
 	 * {@link Throwable} t.
 	 *
 	 * @param faultName the name of the fault
 	 * @param t the {@link Throwable} whose message and stack trace should be read
 	 */
-	public FaultException( String faultName, Throwable t ) {
-		this( faultName, Value.create( t.getMessage() ) );
+	public FaultException( String faultName, Throwable t, ParsingContext context ) {
+		this( faultName, Value.create( t.getMessage() ), context );
 		ByteArrayOutputStream bs = new ByteArrayOutputStream();
 		t.printStackTrace( new PrintStream( bs ) );
 		value.getNewChild( "stackTrace" ).setValue( bs.toString() );
@@ -60,6 +76,16 @@ public class FaultException extends Exception {
 	 */
 	public FaultException( Throwable t ) {
 		this( t.getClass().getSimpleName(), t );
+	}
+
+	/**
+	 * Constructor. Shortcut for {@code FaultException( t.getClass().getSimpleName(), t, context )}.
+	 *
+	 * @param t
+	 * @param context
+	 */
+	public FaultException( Throwable t, ParsingContext context ) {
+		this( t.getClass().getSimpleName(), t, context );
 	}
 
 	/**
@@ -84,18 +110,39 @@ public class FaultException extends Exception {
 	}
 
 	/**
-	 * Constructor.
+	 * Constructor. Shortcut for {@code FaultException( faultName, Value.create( message ), context )}
+	 *
+	 * @param faultName
+	 * @param message
+	 * @param context
+	 */
+	public FaultException( String faultName, String message, ParsingContext context ) {
+		this( faultName, Value.create( message ), context );
+	}
+
+	/**
+	 * Constructor. Shortcut for {@code FaultException( faultName, value, null )}
 	 *
 	 * @param faultName the name of the fault
 	 * @param value the {@link Value} containing the fault data
 	 */
 	public FaultException( String faultName, Value value ) {
+		this( faultName, value, null );
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param faultName the name of the fault
+	 * @param value the {@link Value} containing the fault data
+	 * @param context the {@link ParsingContext} containing info of where the fault happened
+	 */
+	public FaultException( String faultName, Value value, ParsingContext context ) {
 		super();
 		this.faultName = faultName;
 		this.value = value;
-		this.context = null;
+		this.context = context;
 	}
-
 
 
 	/**
@@ -105,6 +152,10 @@ public class FaultException extends Exception {
 	 */
 	public FaultException( String faultName ) {
 		this( faultName, Value.create() );
+	}
+
+	public FaultException( String faultName, ParsingContext context ) {
+		this( faultName, Value.create(), context );
 	}
 
 	@Override
@@ -140,7 +191,7 @@ public class FaultException extends Exception {
 
 	/**
 	 * Creates a new FaultException with a {@link ParsingContext} based on the original FaultException.
-	 * 
+	 *
 	 * @param context The {@link ParsingContext} to be added.
 	 * @return new FaultException with same values apart from the new context.
 	 */

--- a/jolie/src/main/java/jolie/runtime/FaultException.java
+++ b/jolie/src/main/java/jolie/runtime/FaultException.java
@@ -35,7 +35,7 @@ public class FaultException extends Exception {
 	private static final long serialVersionUID = jolie.lang.Constants.serialVersionUID();
 	private final String faultName;
 	private final Value value;
-	private ParsingContext context = null;
+	private final ParsingContext context;
 
 	/**
 	 * Constructor. This constructor behaves as
@@ -63,14 +63,14 @@ public class FaultException extends Exception {
 	}
 
 	/**
-	 * Constructor for cloning FaultException, removing contexts but keeping stacktace.
-	 *
-	 * @param f the FaultException to clone.
+	 * @param f the FaultException that is base for clone.
+	 * @param context the context that the new FaultException should have.
 	 */
-	public FaultException( FaultException f ) {
+	private FaultException( FaultException f, ParsingContext context ) {
 		super( f );
 		this.faultName = f.faultName;
 		this.value = f.value;
+		this.context = context;
 	}
 
 	/**
@@ -93,6 +93,7 @@ public class FaultException extends Exception {
 		super();
 		this.faultName = faultName;
 		this.value = value;
+		this.context = null;
 	}
 
 
@@ -138,16 +139,13 @@ public class FaultException extends Exception {
 	}
 
 	/**
-	 * Adds a {@link ParsingContext} to this FaultException used to know the origin of the Fault. If
-	 * another context is attached it will be overwritten. Returns itself for method-chaining, useful
-	 * when {@link #toRuntimeFaultException()} is needed after.
+	 * Creates a new FaultException with a {@link ParsingContext} based on the original FaultException.
 	 * 
 	 * @param context The {@link ParsingContext} to be added.
-	 * @return A reference to this object.
+	 * @return new FaultException with same values apart from the new context.
 	 */
-	public FaultException addContext( ParsingContext context ) {
-		this.context = context;
-		return this;
+	public FaultException withContext( ParsingContext context ) {
+		return new FaultException( this, context );
 	}
 
 	/**

--- a/jolie/src/main/java/jolie/runtime/FaultException.java
+++ b/jolie/src/main/java/jolie/runtime/FaultException.java
@@ -23,8 +23,8 @@ package jolie.runtime;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-
 import jolie.lang.Constants;
+import jolie.lang.parse.context.ParsingContext;
 
 /**
  * Java representation for a Jolie fault.
@@ -35,6 +35,7 @@ public class FaultException extends Exception {
 	private static final long serialVersionUID = jolie.lang.Constants.serialVersionUID();
 	private final String faultName;
 	private final Value value;
+	private ParsingContext context = null;
 
 	/**
 	 * Constructor. This constructor behaves as
@@ -123,6 +124,27 @@ public class FaultException extends Exception {
 		return new RuntimeFaultException( this );
 	}
 
+	/**
+	 * Adds a {@link ParsingContext} to this FaultException used to know the origin of the Fault. If
+	 * another context is attached it will be overwritten. Returns itself for method-chaining, useful
+	 * when {@link #toRuntimeFaultException()} is needed after.
+	 * 
+	 * @param context The {@link ParsingContext} to be added.
+	 * @return A reference to this object.
+	 */
+	public FaultException addContext( ParsingContext context ) {
+		this.context = context;
+		return this;
+	}
+
+	/**
+	 * @return The source location string for the added context or "Context not present" if context not added.
+	 */
+	public String getContextString() {
+		return context != null ? 
+			context.sourceName() + ":" + context.startLine() : "Context not present";
+	}
+
 	// A RuntimeFaultException is used for runtime errors from which it is
 	// impossible to recover from and continue the execution.
 	// A RuntimeFaultException wraps a FaultException.
@@ -134,6 +156,7 @@ public class FaultException extends Exception {
 		private final FaultException faultException;
 
 		private RuntimeFaultException( FaultException faultException ) {
+			super( faultException );
 			this.faultException = faultException;
 		}
 

--- a/jolie/src/main/java/jolie/runtime/FaultException.java
+++ b/jolie/src/main/java/jolie/runtime/FaultException.java
@@ -138,11 +138,11 @@ public class FaultException extends Exception {
 	}
 
 	/**
-	 * @return The source location string for the added context or "Context not present" if context not added.
+	 * @return The source location string for the added context or "Context not present" if context not
+	 *         added.
 	 */
 	public String getContextString() {
-		return context != null ? 
-			context.sourceName() + ":" + context.startLine() : "Context not present";
+		return context != null ? context.sourceName() + ":" + context.startLine() : "Context not present";
 	}
 
 	// A RuntimeFaultException is used for runtime errors from which it is

--- a/jolie/src/main/java/jolie/runtime/embedding/java/OutputPort.java
+++ b/jolie/src/main/java/jolie/runtime/embedding/java/OutputPort.java
@@ -66,7 +66,7 @@ public class OutputPort {
 			}
 			return response.value();
 		} catch( ExecutionException | InterruptedException | IOException e ) {
-			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e );
+			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e ); // TODO add context?
 		}
 	}
 

--- a/jolie/src/main/java/jolie/runtime/expression/ProductExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/ProductExpression.java
@@ -21,15 +21,18 @@
 
 package jolie.runtime.expression;
 
+import jolie.lang.parse.context.ParsingContext;
 import jolie.process.TransformationReason;
 import jolie.runtime.FaultException;
 import jolie.runtime.Value;
 
 public class ProductExpression implements Expression {
 	private final Operand[] children;
+	private final ParsingContext context;
 
-	public ProductExpression( Operand[] children ) {
+	public ProductExpression( Operand[] children, ParsingContext context ) {
 		this.children = children;
+		this.context = context;
 	}
 
 	@Override
@@ -40,7 +43,7 @@ public class ProductExpression implements Expression {
 		for( Operand operand : children ) {
 			cc[ i++ ] = new Operand( operand.type(), operand.expression().cloneExpression( reason ) );
 		}
-		return new ProductExpression( cc );
+		return new ProductExpression( cc, context );
 	}
 
 	@Override
@@ -56,6 +59,7 @@ public class ProductExpression implements Expression {
 					val.divide( children[ i ].expression().evaluate() );
 				} catch( ArithmeticException ae ) {
 					throw new FaultException( "ArithmeticException", ae.getLocalizedMessage() )
+						.addContext( this.context )
 						.toRuntimeFaultException();
 				}
 				break;

--- a/jolie/src/main/java/jolie/runtime/expression/ProductExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/ProductExpression.java
@@ -58,8 +58,7 @@ public class ProductExpression implements Expression {
 				try {
 					val.divide( children[ i ].expression().evaluate() );
 				} catch( ArithmeticException ae ) {
-					throw new FaultException( "ArithmeticException", ae.getLocalizedMessage() )
-						.withContext( this.context )
+					throw new FaultException( "ArithmeticException", ae.getLocalizedMessage(), this.context )
 						.toRuntimeFaultException();
 				}
 				break;

--- a/jolie/src/main/java/jolie/runtime/expression/ProductExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/ProductExpression.java
@@ -59,7 +59,7 @@ public class ProductExpression implements Expression {
 					val.divide( children[ i ].expression().evaluate() );
 				} catch( ArithmeticException ae ) {
 					throw new FaultException( "ArithmeticException", ae.getLocalizedMessage() )
-						.addContext( this.context )
+						.withContext( this.context )
 						.toRuntimeFaultException();
 				}
 				break;

--- a/jolie/src/main/java/jolie/runtime/expression/SolicitResponseExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/SolicitResponseExpression.java
@@ -195,9 +195,9 @@ public class SolicitResponseExpression implements Expression {
 						}
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 							"Received fault " + response.fault().faultName() + " TypeMismatch (" + operationId + "@"
-								+ outputPort.id() + "): " + e.getMessage() )
-									.withContext( this.context )
-									.toRuntimeFaultException();
+								+ outputPort.id() + "): " + e.getMessage(),
+							this.context )
+							.toRuntimeFaultException();
 					}
 				} else {
 					if( Interpreter.getInstance().isMonitoring() ) {
@@ -208,7 +208,7 @@ public class SolicitResponseExpression implements Expression {
 								Long.toString( response.id() ) ) );
 					}
 				}
-				throw response.fault();
+				throw response.fault().withContext( context ).toRuntimeFaultException();
 			} else {
 				if( types.responseType() != null ) {
 					try {
@@ -231,9 +231,8 @@ public class SolicitResponseExpression implements Expression {
 									Long.toString( response.id() ) ) );
 						}
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "Received message TypeMismatch ("
-							+ operationId + "@" + outputPort.id() + "): " + e.getMessage() )
-								.withContext( this.context )
-								.toRuntimeFaultException();
+							+ operationId + "@" + outputPort.id() + "): " + e.getMessage(), this.context )
+							.toRuntimeFaultException();
 					}
 				} else {
 					if( Interpreter.getInstance().isMonitoring() ) {
@@ -245,22 +244,18 @@ public class SolicitResponseExpression implements Expression {
 				}
 			}
 		} catch( TimeoutException e ) { // The response timed out
-			throw new FaultException( Constants.TIMEOUT_EXCEPTION_FAULT_NAME )
-				.withContext( this.context )
+			throw new FaultException( Constants.TIMEOUT_EXCEPTION_FAULT_NAME, this.context )
 				.toRuntimeFaultException();
 		} catch( IOException e ) {
-			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e )
-				.withContext( this.context )
+			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e, this.context )
 				.toRuntimeFaultException();
 		} catch( URISyntaxException e ) {
 			Interpreter.getInstance().logSevere( e );
 		} catch( TypeCheckingException e ) {
 			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
-				"Output message TypeMismatch (" + operationId + "@" + outputPort.id() + "): " + e.getMessage() )
-					.withContext( this.context )
-					.toRuntimeFaultException();
-		} catch( FaultException e ) {
-			throw e.withContext( this.context ).toRuntimeFaultException();
+				"Output message TypeMismatch (" + operationId + "@" + outputPort.id() + "): " + e.getMessage(),
+				this.context )
+				.toRuntimeFaultException();
 		} finally {
 			if( channel != null ) {
 				try {

--- a/jolie/src/main/java/jolie/runtime/expression/SolicitResponseExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/SolicitResponseExpression.java
@@ -26,7 +26,6 @@ import java.net.URISyntaxException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import jolie.ExecutionThread;
 import jolie.Interpreter;
 import jolie.lang.Constants;
@@ -197,6 +196,7 @@ public class SolicitResponseExpression implements Expression {
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 							"Received fault " + response.fault().faultName() + " TypeMismatch (" + operationId + "@"
 								+ outputPort.id() + "): " + e.getMessage() )
+							.addContext( this.context )
 							.toRuntimeFaultException();
 					}
 				} else {
@@ -231,7 +231,9 @@ public class SolicitResponseExpression implements Expression {
 									Long.toString( response.id() ) ) );
 						}
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "Received message TypeMismatch ("
-							+ operationId + "@" + outputPort.id() + "): " + e.getMessage() ).toRuntimeFaultException();
+							+ operationId + "@" + outputPort.id() + "): " + e.getMessage() )
+							.addContext( this.context )
+							.toRuntimeFaultException();
 					}
 				} else {
 					if( Interpreter.getInstance().isMonitoring() ) {
@@ -243,14 +245,19 @@ public class SolicitResponseExpression implements Expression {
 				}
 			}
 		} catch( TimeoutException e ) { // The response timed out
-			throw new FaultException( Constants.TIMEOUT_EXCEPTION_FAULT_NAME ).toRuntimeFaultException();
+			throw new FaultException( Constants.TIMEOUT_EXCEPTION_FAULT_NAME )
+				.addContext( this.context )
+				.toRuntimeFaultException();
 		} catch( IOException e ) {
-			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e ).toRuntimeFaultException();
+			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e )
+				.addContext( this.context )
+				.toRuntimeFaultException();
 		} catch( URISyntaxException e ) {
 			Interpreter.getInstance().logSevere( e );
 		} catch( TypeCheckingException e ) {
 			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 				"Output message TypeMismatch (" + operationId + "@" + outputPort.id() + "): " + e.getMessage() )
+				.addContext( this.context )
 				.toRuntimeFaultException();
 		} catch( FaultException e ) {
 			throw e.toRuntimeFaultException();

--- a/jolie/src/main/java/jolie/runtime/expression/SolicitResponseExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/SolicitResponseExpression.java
@@ -196,8 +196,8 @@ public class SolicitResponseExpression implements Expression {
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 							"Received fault " + response.fault().faultName() + " TypeMismatch (" + operationId + "@"
 								+ outputPort.id() + "): " + e.getMessage() )
-							.addContext( this.context )
-							.toRuntimeFaultException();
+									.addContext( this.context )
+									.toRuntimeFaultException();
 					}
 				} else {
 					if( Interpreter.getInstance().isMonitoring() ) {
@@ -232,8 +232,8 @@ public class SolicitResponseExpression implements Expression {
 						}
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "Received message TypeMismatch ("
 							+ operationId + "@" + outputPort.id() + "): " + e.getMessage() )
-							.addContext( this.context )
-							.toRuntimeFaultException();
+								.addContext( this.context )
+								.toRuntimeFaultException();
 					}
 				} else {
 					if( Interpreter.getInstance().isMonitoring() ) {
@@ -257,10 +257,10 @@ public class SolicitResponseExpression implements Expression {
 		} catch( TypeCheckingException e ) {
 			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 				"Output message TypeMismatch (" + operationId + "@" + outputPort.id() + "): " + e.getMessage() )
-				.addContext( this.context )
-				.toRuntimeFaultException();
+					.addContext( this.context )
+					.toRuntimeFaultException();
 		} catch( FaultException e ) {
-			throw e.toRuntimeFaultException();
+			throw e.addContext( this.context ).toRuntimeFaultException();
 		} finally {
 			if( channel != null ) {
 				try {

--- a/jolie/src/main/java/jolie/runtime/expression/SolicitResponseExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/SolicitResponseExpression.java
@@ -196,7 +196,7 @@ public class SolicitResponseExpression implements Expression {
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 							"Received fault " + response.fault().faultName() + " TypeMismatch (" + operationId + "@"
 								+ outputPort.id() + "): " + e.getMessage() )
-									.addContext( this.context )
+									.withContext( this.context )
 									.toRuntimeFaultException();
 					}
 				} else {
@@ -232,7 +232,7 @@ public class SolicitResponseExpression implements Expression {
 						}
 						throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME, "Received message TypeMismatch ("
 							+ operationId + "@" + outputPort.id() + "): " + e.getMessage() )
-								.addContext( this.context )
+								.withContext( this.context )
 								.toRuntimeFaultException();
 					}
 				} else {
@@ -246,21 +246,21 @@ public class SolicitResponseExpression implements Expression {
 			}
 		} catch( TimeoutException e ) { // The response timed out
 			throw new FaultException( Constants.TIMEOUT_EXCEPTION_FAULT_NAME )
-				.addContext( this.context )
+				.withContext( this.context )
 				.toRuntimeFaultException();
 		} catch( IOException e ) {
 			throw new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e )
-				.addContext( this.context )
+				.withContext( this.context )
 				.toRuntimeFaultException();
 		} catch( URISyntaxException e ) {
 			Interpreter.getInstance().logSevere( e );
 		} catch( TypeCheckingException e ) {
 			throw new FaultException( Constants.TYPE_MISMATCH_FAULT_NAME,
 				"Output message TypeMismatch (" + operationId + "@" + outputPort.id() + "): " + e.getMessage() )
-					.addContext( this.context )
+					.withContext( this.context )
 					.toRuntimeFaultException();
 		} catch( FaultException e ) {
-			throw e.addContext( this.context ).toRuntimeFaultException();
+			throw e.withContext( this.context ).toRuntimeFaultException();
 		} finally {
 			if( channel != null ) {
 				try {


### PR DESCRIPTION
Pull request for adding location data / line number to faults (see #514)

I've combed over every place that creates a fault and all the places that I could find that forwards them.

I've tested the following manually and seen that they report line numbers(nearly correctly see #582):

- throwing faults
- causing faults from arithmetic (divide by zero and ++ operator on non numbers)
- faults coming from calls (examples call@service()() )
- faults forwarded by forward statement
- faults send over Local and not (used sodep)
- TypeMismatch that are thrown as fault have context (some TypeMismatch arning are logged not using faults)

There exists some exception that can come up in ScopeProcess and OutputPort which I've not found ways to test.