### PR TITLE
AggregatedOperation - pass the original request to the response

### DIFF
--- a/jolie/src/main/java/jolie/net/AggregatedOperation.java
+++ b/jolie/src/main/java/jolie/net/AggregatedOperation.java
@@ -250,7 +250,7 @@ public abstract class AggregatedOperation {
 				final CommMessage response = oChannel.recvResponseFor( requestToAggregated ).get();
 				channel.send(
 					new CommMessage( requestMessage.requestId(), response.operationName(), response.resourcePath(),
-						response.value(), response.fault(), null ) );
+						response.value(), response.fault(), requestMessage ) );
 			} catch( InterruptedException | ExecutionException | IOException e ) {
 				channel.send( CommMessage.createFaultResponse( requestMessage,
 					new FaultException( Constants.IO_EXCEPTION_FAULT_NAME, e ) ) );


### PR DESCRIPTION
otherwise the request's metadata (e.g. http content negotiation) gets lost