### PR TITLE
added test for extender in embed without 'as' keyword

### DIFF
--- a/jolie/src/main/java/jolie/runtime/embedding/JolieServiceNodeLoader.java
+++ b/jolie/src/main/java/jolie/runtime/embedding/JolieServiceNodeLoader.java
@@ -26,6 +26,9 @@ import java.nio.file.Paths;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import jolie.Interpreter;
+import jolie.lang.parse.ast.InputPortInfo;
+import jolie.lang.parse.ast.InputPortInfo.AggregationItemInfo;
+import jolie.lang.parse.ast.OLSyntaxNode;
 import jolie.lang.parse.ast.ServiceNode;
 import jolie.lang.parse.util.ProgramBuilder;
 import jolie.runtime.Value;
@@ -53,6 +56,16 @@ public class JolieServiceNodeLoader extends ServiceNodeLoader {
 			ProgramBuilder builder = new ProgramBuilder( serviceNode().context() );
 			builder.addChild( serviceNode() );
 
+			// add all interface extender definitions to program builder
+			for( OLSyntaxNode node : serviceNode().program().children() ) {
+				if( node instanceof InputPortInfo ) {
+					for( AggregationItemInfo aggregationItemInfo : ((InputPortInfo) node).aggregationList() ) {
+						if( aggregationItemInfo.interfaceExtender() != null ) {
+							builder.addChild( aggregationItemInfo.interfaceExtender() );
+						}
+					}
+				}
+			}
 			interpreter = new Interpreter(
 				configuration,
 				interpreter().symbolTables(),

--- a/test/primitives/extender.ol
+++ b/test/primitives/extender.ol
@@ -42,8 +42,8 @@ service EmbedderService {
 
   courier input {
     [ nothing( request )( response ){
-      response.token = 1
       forward( request )( response )
+      response.token = 1
     } ]
   }
 

--- a/test/primitives/extender2.ol
+++ b/test/primitives/extender2.ol
@@ -13,7 +13,7 @@ interface NothingServiceInterface {
 service NothingService {
 
     inputPort TaskService2 {
-      location: "local"
+      location: "local://NothingService"
       interfaces: NothingServiceInterface
     }
 
@@ -32,18 +32,23 @@ interface extender TokenExtender {
 
 service EmbedderService {
 
-  embed NothingService as NothingService
+  embed NothingService
+
+  outputPort NothingService {
+    Location: "local://NothingService"
+    Interfaces: NothingServiceInterface
+  }
 
   inputPort input {    
-    location: "local"
+    location: "local://EmbedderService"
     protocol: "sodep"
     aggregates: NothingService with TokenExtender
   }
 
   courier input {
     [ nothing( request )( response ){
-      response.token = 1
       forward( request )( response )
+      response.token = 1
     } ]
   }
 
@@ -53,11 +58,24 @@ service EmbedderService {
 
 }
 
+type TestWithTokenType {
+  header: string
+  token: int
+}
 
+interface NothingServiceInterfaceWithToken {
+  requestResponse:
+    nothing( TestWithTokenType )( TokenType ) throws InvalidToken
+}
 
 service Main {
 
-    embed EmbedderService as EmbedderService
+    embed EmbedderService
+
+    outputPort EmbedderService {
+      Location: "local://EmbedderService"
+      Interfaces: NothingServiceInterfaceWithToken
+    }
 
     inputPort TestUnitInput {
         location: "local"


### PR DESCRIPTION
In commit 18bfb4798235a3b93900ba284dd760fad53e9d76 I fixed partly the bug, as I only tested on a service that used embed without as.
So I made a test for this specifically(`extender2.ol`), which in a way is subset of what's being tested in `extender.ol`.