### PR TITLE
added getHashMap api

### DIFF
--- a/packages/trees.ol
+++ b/packages/trees.ol
@@ -1,0 +1,55 @@
+/*
+ *   Copyright (C) 2025 by Claudio Guidi <cguidi@italianasoftware.com>          
+ *                                                                         
+ *   This program is free software; you can redistribute it and/or modify  
+ *   it under the terms of the GNU Library General Public License as       
+ *   published by the Free Software Foundation; either version 2 of the    
+ *   License, or (at your option) any later version.                       
+ *                                                                         
+ *   This program is distributed in the hope that it will be useful,       
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         
+ *   GNU General Public License for more details.                          
+ *                                                                         
+ *   You should have received a copy of the GNU Library General Public     
+ *   License along with this program; if not, write to the                 
+ *   Free Software Foundation, Inc.,                                       
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             
+ *                                                                         
+ *   For details about the authors of this software, see the AUTHORS file. 
+ */
+
+from string-utils import StringUtils
+
+type GetHashMapRequest {
+    vector* {?}
+    key: string 
+}
+
+interface TreesInterface {
+    RequestResponse:
+        getHashMap( GetHashMapRequest )( undefined )
+}
+
+ service Trees {
+
+    embed StringUtils as StringUtils
+
+    execution: concurrent
+
+    inputPort Trees {
+        location: "local"
+        interfaces: TreesInterface
+    }
+
+    main {
+        [ getHashMap( request )( response ) {
+            for( i in request.vector ) {
+                response.( i.( request.key ) ) << i
+            }
+        }]
+    }
+
+
+ }
+

--- a/test/library/trees.ol
+++ b/test/library/trees.ol
@@ -1,0 +1,40 @@
+from ..test-unit import TestUnitInterface
+from trees import Trees
+
+service Main {
+
+    embed Trees as Trees
+
+    inputPort TestUnitInput {
+        location: "local"
+        interfaces: TestUnitInterface
+    }
+
+    main {
+        test()() {  
+            for( x = 0, x < 100, x++ ) {
+                a.c.d.f[ x ] << {
+                    testString = "testString"
+                    mykey = "key" + x
+                    x = x
+                }
+            }
+            getHashMap@Trees( {
+                vector -> a.c.d.f 
+                key = "mykey"
+            })( hashmap )
+
+            count = 0
+            foreach( y : hashmap ) {
+                count++
+                if ( y != hashmap.( y ).mykey ) {
+                    throw( TestFailed, "Key not correspond, expected " + y + " found " + hashmap.( y ).mykey )
+                }
+            }
+
+            if ( count != 100 ) {
+                throw( TestFailed, "expected 100 keys, found " + count )
+            }
+        }
+    }
+}


### PR DESCRIPTION
very useful functionality. It should be implemented as a native statement into the language.
It could be nice to have a transformation from vectors to maps and viceversa

an example of usage can be found in the test

```
for( x = 0, x < 100, x++ ) {
    a.c.d.f[ x ] << {
        testString = "testString"
        mykey = "key" + x
        x = x
    }
}
getHashMap@Trees( {
    vector -> a.c.d.f 
    key = "mykey"
})( hashmap )

count = 0
foreach( y : hashmap ) {
    count++
    if ( y != hashmap.( y ).mykey ) {
        throw( TestFailed, "Key not correspond, expected " + y + " found " + hashmap.( y ).mykey )
    }
}

if ( count != 100 ) {
    throw( TestFailed, "expected 100 keys, found " + count )
}
```