### PR TITLE
Add support for Java system properties in jolie-cli and runtime service

### DIFF
--- a/javaServices/coreJavaServices/src/main/java/joliex/lang/RuntimeService.java
+++ b/javaServices/coreJavaServices/src/main/java/joliex/lang/RuntimeService.java
@@ -265,6 +265,51 @@ public class RuntimeService extends JavaService {
 		return retVal;
 	}
 
+	public Value getProperty( Value request ) {
+		final String prop = System.getProperty( request.strValue() );
+		final Value response = Value.create();
+		if( prop != null ) {
+			response.setValue( prop );
+		} else if( request.hasChildren( "default" ) ) {
+			response.setValue( request.getFirstChild( "default" ).strValue() );
+		}
+		return response;
+	}
+
+	public Value getProperties() {
+		final Value response = Value.create();
+		for( String key : System.getProperties().stringPropertyNames() ) {
+			Value entry = response.getNewChild( key );
+			entry.setValue( System.getProperty( key ) );
+		}
+		return response;
+	}
+
+	public Value clearProperty( String key ) {
+		final String previous = System.clearProperty( key );
+		if( previous != null ) {
+			final Value response = Value.create();
+			response.setValue( previous );
+			return response;
+		} else {
+			return Value.create();
+		}
+	}
+
+	@SuppressWarnings( "PMD.LinguisticNaming" )
+	public Value setProperty( Value request ) {
+		final String key = request.getFirstChild( "key" ).strValue();
+		final String value = request.getFirstChild( "value" ).strValue();
+		final String previous = System.setProperty( key, value );
+		if( previous != null ) {
+			final Value response = Value.create();
+			response.setValue( previous );
+			return response;
+		} else {
+			return Value.create();
+		}
+	}
+
 	@RequestResponse
 	public void loadLibrary( String libraryPath )
 		throws FaultException {

--- a/jolie-cli/src/main/java/jolie/cli/CommandLineParser.java
+++ b/jolie-cli/src/main/java/jolie/cli/CommandLineParser.java
@@ -183,6 +183,8 @@ public class CommandLineParser implements AutoCloseable {
 						+ Integer.MAX_VALUE + ")" ) )
 			.append(
 				getOptionString( "--stackTraces", "Print stack traces (default: false)" ) )
+			.append(
+				getOptionString( "-D<name>=<value>", "Set system property <name> to <value>" ) )
 			.toString();
 	}
 
@@ -468,6 +470,20 @@ public class CommandLineParser implements AutoCloseable {
 				}
 			} else if( "--version".equals( argsList.get( i ) ) ) {
 				throw new CommandLineException( getVersionString() );
+			} else if( argsList.get( i ).startsWith( "-D" ) ) {
+				// handle -D<name>=<value>
+				String[] parts = argsList.get( i ).substring( 2 ).split( "=", 2 );
+				try {
+					System.setProperty( parts[ 0 ], parts[ 1 ] );
+				} catch( SecurityException e ) {
+					// thrown if a security manager exists and its checkPermission method doesn't allow setting of the
+					// specified property.
+					throw new CommandLineException( "Cannot set system property: " + parts[ 0 ] );
+				} catch( IndexOutOfBoundsException | IllegalArgumentException | NullPointerException e ) {
+					// thrown if the parameter is not well formed
+					throw new CommandLineException(
+						"Invalid system property definition '" + argsList.get( i ) + "', expected -D<name>=<value>" );
+				}
 			} else if( olFilepath == null && !argsList.get( i ).startsWith( "-" ) ) {
 				final String path = argsList.get( i );
 				if( path.endsWith( ".jap" ) ) {

--- a/packages/runtime.ol
+++ b/packages/runtime.ol
@@ -89,6 +89,16 @@ type GetOutputPortsResponse: void {
 	}
 }
 
+type GetPropertyRequest: string(regex(".+")) {
+	/// The default value returned if there is no property with that key.
+	.default?: string 
+}
+
+type SetPropertyRequest: void {
+	.key:NonEmptyString //< The name of the system property.
+	.value:string //< The value of the system property.
+}
+
 type HaltRequest: void {
 	.status?: int //< The status code to return to the execution environment
 }
@@ -115,6 +125,7 @@ type Stats:void {
 	}
 }
 
+type NonEmptyString : string(regex(".+"))
 type MaybeString:void | string
 
 interface RuntimeInterface {
@@ -191,6 +202,18 @@ RequestResponse:
 
 	/// Returns the value of an environment variable.
 	getenv(string)(MaybeString),
+
+	/// Returns the value of a system variable.If the property is not preset it returns void or a default value if one is provided.
+	getProperty(GetPropertyRequest)(MaybeString),
+
+	/// Returns all system properties (the value of a property is stored under a node named as the property). 
+	getProperties(void)(undefined),
+
+	/// Removes the value of a system variable and returns the previous string value of the system property, or void if there was no property with that key.
+	clearProperty(NonEmptyString)(MaybeString),
+
+	/// Sets the value of a system variable and returns the previous string value of the system property, or void if there was no property with that key.
+	setProperty(SetPropertyRequest)(MaybeString),
 
 	/// Returns the version of the Jolie interpreter running this service.
 	getVersion(void)(string)

--- a/test/library/runtime-properties.ol
+++ b/test/library/runtime-properties.ol
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2025 Fabrizio Montesi <famontesi@gmail.com>
+ * Copyright (C) 2025 Marco Peressotti <marco.peressotti@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+from ..test-unit import TestUnitInterface
+from runtime import Runtime
+from console import Console
+
+/**
+	A template for test units.
+*/
+service Main {
+	embed Runtime as runtime
+	embed Console as console
+
+	inputPort TestUnitInput {
+		location: "local"
+		interfaces: TestUnitInterface
+	}
+
+	main {
+		test()() {
+			/* Assumptions
+			 * - key is the name of a system property that is not defined when the test starts and that the security manager allows to set it.
+			 * - default, value1, and value2 are distinct, non-empty strings.
+       */ 
+			key = "jolie.temp" 
+			default = "default"
+			value1 = "value 1"
+			value2 = "value 2"
+			// reading an undefined property retuns void or the default value if one is provided
+			getProperty@runtime(key)( res[1] )
+			getProperty@runtime(key{ .default = default })( res[2] );
+			if( res[1] != void || res[2] != default ) {
+			 	throw( TestFailed, "getProperty, unexpected result" )
+			}
+			undef(res)
+			// setProperty updates a property and returns the previous value
+			setProperty@runtime({ key = key value = value1 })( res[0] );
+			setProperty@runtime({ key = key value = value2 })( res[1] );
+			getProperty@runtime(key)( res[2] );
+			if( res[0] != void || res[1] != value1 || res[2] != value2 ) {
+			 	throw( TestFailed, "setProperty, unexpected result" )
+			}
+			undef(res)
+			// getProperties 
+			getProperties@runtime()( props );
+			foreach( k : props ) {
+				getProperty@runtime(k)( prop );
+				if( props.(k) != prop ) {
+					throw( TestFailed, "getProperties, unexpected result" )
+				}
+			}
+			// clearProperty clears a property and returns the previous value
+			clearProperty@runtime(key)( res[0] )
+			getProperty@runtime(key)( res[1] )
+			if( res[0] != value2 || res[1] != void ) {
+			 	throw( TestFailed, "clearProperty, unexpected result" )
+			}
+			// illegal keys are rejected as type mismatches on the client side
+			failed = true
+			scope(f) {
+				install(IllegalArgumentException => nullProcess )
+				install( TypeMismatch => failed = false )
+				getProperty@runtime("")( )
+			}
+			if( failed ) {
+				throw( TestFailed, "empty keys are not rejected" )
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces features for interacting with Java system properties:
 - `jolie-cli` now supports `-D<name>=<value>` arguments to set system properties at launch.
 - service `Runtime` provides operations for managing system properties, including enumeration, reading, writing, and clearing—leveraging methods of Java's `System` class.