### PR TITLE
release.sh - missing shebang

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 VER=$1
 if [ -z "$VER" ]; then
 	echo "Usage: $0 <version>"


### PR DESCRIPTION
Furthermore we should decide if we should consistently use the shell script's file extension .sh or not.