### PR TITLE
Potential fix for code scanning alert no. 2692: Container contents are never accessed

### DIFF
--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
@@ -957,13 +957,11 @@ public class SymbolReferenceResolver {
 	 */
 	private static InterfacesAndOperations getInterfacesFromInputPortLocal(
 		ServiceNode node ) {
-		Map< String, OutputPortInfo > internalOp = new HashMap<>();
 		InterfacesAndOperations result = new InterfacesAndOperations();
 
 		for( OLSyntaxNode n : node.program().children() ) {
 			if( n instanceof OutputPortInfo ) {
-				OutputPortInfo op = (OutputPortInfo) n;
-				internalOp.put( op.id(), op );
+				// OutputPortInfo nodes are currently not processed further.
 			} else if( n instanceof InputPortInfo ) {
 				InputPortInfo ip = (InputPortInfo) n;
 				if( ip.location() instanceof ConstantStringExpression ) {


### PR DESCRIPTION
Potential fix for [https://github.com/jolie/jolie/security/code-scanning/2692](https://github.com/jolie/jolie/security/code-scanning/2692)

To fix the issue, we should remove the `internalOp` map entirely, as it is not accessed or used in the method. This will eliminate the dead code and improve code clarity. If the map is intended for future use, a comment can be added to document its purpose, but as it stands, it is better to remove it to avoid confusion.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
