### PR TITLE
Fix extend  typelink linked type is null

### DIFF
--- a/jolie/src/main/java/jolie/OOITBuilder.java
+++ b/jolie/src/main/java/jolie/OOITBuilder.java
@@ -1688,6 +1688,7 @@ public class OOITBuilder implements UnitOLVisitor {
 				extendTypes[ i ] = typeMap.get( extendedTypeDefinition );
 			} else {
 				extendTypes[ i ] = buildType( extendedTypeDefinition );
+				resolveTypeLinks(); // quickfix for bug when it is a TypeLink being build
 			}
 			result = Type.extend( result, extendTypes[ i ] );
 			i++;

--- a/jolie/src/main/java/jolie/OOITBuilder.java
+++ b/jolie/src/main/java/jolie/OOITBuilder.java
@@ -1688,8 +1688,8 @@ public class OOITBuilder implements UnitOLVisitor {
 				extendTypes[ i ] = typeMap.get( extendedTypeDefinition );
 			} else {
 				extendTypes[ i ] = buildType( extendedTypeDefinition );
-				resolveTypeLinks(); // quickfix for bug when it is a TypeLink being build
 			}
+			resolveTypeLinks(); // quickfix for bug when it is a TypeLink being build
 			result = Type.extend( result, extendTypes[ i ] );
 			i++;
 		}

--- a/jolie/src/main/java/jolie/runtime/typing/Type.java
+++ b/jolie/src/main/java/jolie/runtime/typing/Type.java
@@ -381,8 +381,10 @@ public abstract class Type {
 		} else if( t2 instanceof TypeLink ) {
 			returnType = extend( t1, (TypeLink) t2 );
 		} else {
-			throw new UnsupportedOperationException( "extension not supported between " + t1.getClass().getSimpleName()
-				+ " and " + t2.getClass().getSimpleName() );
+			String t1Name = t1 != null ? t1.getClass().getSimpleName() : "(null error)";
+			String t2Name = t2 != null ? t2.getClass().getSimpleName() : "(null error)";
+			throw new UnsupportedOperationException( "extension not supported between " + t1Name
+				+ " and " + t2Name );
 		}
 		return returnType;
 	}
@@ -396,14 +398,16 @@ public abstract class Type {
 		} else if( t1 instanceof TypeLink ) {
 			returnType = extend( (TypeLink) t1, t2 );
 		} else {
-			throw new UnsupportedOperationException( "extension not supported between " + t1.getClass().getSimpleName()
-				+ " and " + t2.getClass().getSimpleName() );
+			String t1Name = t1 != null ? t1.getClass().getSimpleName() : "(null error)";
+			String t2Name = t2 != null ? t2.getClass().getSimpleName() : "(null error)";
+			throw new UnsupportedOperationException( "extension not supported between " + t1Name
+				+ " and " + t2Name );
 		}
 		return returnType;
 	}
 
 	private static Type extend( TypeLink t1, TypeImpl t2 ) {
-		return extend( t1.linkedType, t2 );
+		return extend( t1.linkedType, t2 ); // maybe throw exception here if linkedType is null?
 	}
 
 	private static Type extend( TypeChoice t1, TypeImpl t2 ) {
@@ -411,7 +415,7 @@ public abstract class Type {
 	}
 
 	private static Type extend( Type t1, TypeLink t2 ) {
-		return extend( t1, t2.linkedType );
+		return extend( t1, t2.linkedType ); // maybe throw exception here if linkedType is null?
 	}
 
 	private static Type extend( Type t1, TypeChoice t2 ) {

--- a/test/primitives/extend-typelinked.ol
+++ b/test/primitives/extend-typelinked.ol
@@ -1,0 +1,91 @@
+from ..test-unit import TestUnitInterface
+from .private.TypeLink_for_extend import typeInOtherFile
+
+
+
+type TestType {
+  header: string
+}
+
+interface NothingServiceInterface {
+  requestResponse:
+    nothing( TestType )( void )
+}
+
+service NothingService {
+
+    inputPort TaskService2 {
+      location: "local"
+      interfaces: NothingServiceInterface
+    }
+
+    main {
+        nothing( req )( res ) { nullProcess }
+    }
+}
+
+interface extender TokenExtender {
+  RequestResponse:
+    *( typeInOtherFile )( typeInOtherFile ) throws InvalidToken
+}
+
+service EmbedderService {
+
+  embed NothingService as NothingService
+
+  inputPort input {
+    location: "local://EmbedderServiceTypeLink"
+    aggregates: NothingService with TokenExtender
+  }
+
+  courier input {
+    [ nothing( request )( response ){
+      forward( request )( response )
+      response.token = 2
+    } ]
+  }
+
+  main {
+    linkIn(l)
+  }
+
+}
+
+type TestWithTokenType {
+  header: string
+  token: int
+}
+
+interface NothingServiceInterfaceWithToken {
+  requestResponse:
+    nothing( TestWithTokenType )( typeInOtherFile ) throws InvalidToken
+}
+
+service Main {
+
+    embed EmbedderService
+
+    outputPort EmbedderService {
+        location: "local://EmbedderServiceTypeLink"
+        interfaces: NothingServiceInterfaceWithToken
+    }
+
+    inputPort TestUnitInput {
+        location: "local"
+        interfaces: TestUnitInterface
+    }
+
+    main {
+        test()() {
+            nothing@EmbedderService({
+                header = "test"
+                token = 1
+            })(r)
+            if ( r.token != 2 ) {
+              throw( TestFailed, "expect response.token to be " + 2 + ", got " + r.token )
+            }
+        }
+    }
+
+}
+

--- a/test/primitives/extend-typelinked2.ol
+++ b/test/primitives/extend-typelinked2.ol
@@ -1,0 +1,86 @@
+from ..test-unit import TestUnitInterface
+from .private.TypeLink_for_extend import typeInOtherFile
+
+
+
+type TestType {
+  header: string
+}
+
+interface NothingServiceInterface {
+  requestResponse:
+    nothing( TestType )( void )
+}
+
+service NothingService {
+
+    inputPort TaskService2 {
+      location: "local"
+      interfaces: NothingServiceInterface
+    }
+
+    main {
+        nothing( req )( res ) { nullProcess }
+    }
+}
+
+interface extender TokenExtender {
+  RequestResponse:
+    *( typeInOtherFile )( typeInOtherFile ) throws InvalidToken
+}
+
+service EmbedderService {
+
+  embed NothingService as NothingService
+
+  inputPort input {
+    location: "local"
+    aggregates: NothingService with TokenExtender
+  }
+
+  courier input {
+    [ nothing( request )( response ){
+      forward( request )( response )
+      response.token = 2
+    } ]
+  }
+
+  main {
+    linkIn(l)
+  }
+
+}
+
+type TestWithTokenType {
+  header: string
+  token: int
+}
+
+interface NothingServiceInterfaceWithToken {
+  requestResponse:
+    nothing( TestWithTokenType )( typeInOtherFile ) throws InvalidToken
+}
+
+service Main {
+
+    embed EmbedderService as EmbedderService
+
+    inputPort TestUnitInput {
+        location: "local"
+        interfaces: TestUnitInterface
+    }
+
+    main {
+        test()() {
+            nothing@EmbedderService({
+                header = "test"
+                token = 1
+            })(r)
+            if ( r.token != 2 ) {
+              throw( TestFailed, "expect response.token to be " + 2 + ", got " + r.token )
+            }
+        }
+    }
+
+}
+

--- a/test/primitives/private/TypeLink_for_extend.ol
+++ b/test/primitives/private/TypeLink_for_extend.ol
@@ -1,0 +1,3 @@
+type typeInOtherFile {
+    token: int
+}


### PR DESCRIPTION
A bug exists in using a type from another file in an extender.
I created two tests that tests for this when using embed with as, and using embed without as.
The bug only seems to happen when embedding without as.

What happens is: that the Type Link is build, but the link is not added. This also gives a null exception when trying to throw new UnsupportedOperationException, so some Null checking has been put in.

I have also found the source that has the problem and applied a quickfix.

This bug has been introduced in Jolie 1.13, and did not exist in Jolie 1.12.