### PR TITLE
Corrects path resolution for service directory

### DIFF
--- a/javaServices/coreJavaServices/src/main/java/joliex/io/FileService.java
+++ b/javaServices/coreJavaServices/src/main/java/joliex/io/FileService.java
@@ -522,7 +522,7 @@ public class FileService extends JavaService {
 	public String getRealServiceDirectory()
 		throws FaultException {
 		try {
-			return Paths.get( interpreter().configuration().source().uri() ).getParent().toRealPath().toString();
+			return Paths.get( interpreter().configuration().source().uri() ).toRealPath().getParent().toString();
 		} catch( IOException e ) {
 			throw new FaultException( "IOException", e );
 		}


### PR DESCRIPTION
Modifies path resolution to correctly by reordering path operations.

This fixes lib path resolution when execute script symlinked to other dir. e.g. when running a script from with npx.
