### PR TITLE
Allow Jolie to run ol files that exist in folders with spaces in them 

### DIFF
--- a/jolie-cli/src/main/java/jolie/cli/CommandLineParser.java
+++ b/jolie-cli/src/main/java/jolie/cli/CommandLineParser.java
@@ -726,7 +726,7 @@ public class CommandLineParser implements AutoCloseable {
 		File f = new File( olFilepath ).getAbsoluteFile();
 		if( f.exists() ) {
 			result.stream = new FileInputStream( f );
-			result.source = f.toURI().getSchemeSpecificPart();
+			result.source = f.toURI().toString();
 		} else if( olFilepath.startsWith( "jap" ) ) {
 			olURL = new URL( olFilepath );
 			result.stream = olURL.openStream();


### PR DESCRIPTION
fix: changed from using getSchemeSpecificPart to toString, to handle spaces being encoded for URI.

