### PR TITLE
enable being able to create install jar in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,6 +27,9 @@ RUN apt-get update
 # Install sudo
 RUN apt-get install -y sudo
 
+#Install zip for creating install jar
+RUN apt-get install -y zip
+
 # Set JOLIE_HOME
 ENV JOLIE_HOME=/usr/bin/jolie-dist
 


### PR DESCRIPTION
When I want to compile an install Jar with changes for testing I use the devcontainer because some other more complex errors happens on windows.
I think it would be nice to have in master branch too.