### PR TITLE
Added launch options for traceLevel and stackTraces

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,9 @@
 				"-p",
 				"${workspaceFolder}/packages",
 				"${input:trace}",
+				"--traceLevel",
+				"${input:traceLevel}",
+				"${input:stackTraces}",
 				"--responseTimeout",
 				"300000",
 				"${input:programName}"
@@ -29,6 +32,9 @@
 					"-p",
 					"${workspaceFolder}\\packages",
 					"${input:trace}",
+					"--traceLevel",
+					"${input:traceLevel}",
+					"${input:stackTraces}",
 					"--responseTimeout",
 					"300000",
 					"${input:programName}"
@@ -151,6 +157,27 @@
 				"--trace",
 			],
 			"default": ""
+		},
+		{
+			"type": "pickString",
+			"id": "stackTraces",
+			"description": "Run with --stackTraces?",
+			"options": [
+				"",
+				"--stackTraces"
+			],
+			"default": ""
+		},
+		{
+			"type": "pickString",
+			"id": "traceLevel",
+			"description": "select trace level",
+			"options": [
+				"all",
+				"comm",
+				"comp"
+			],
+			"default": "all"
 		}
 	]
 }


### PR DESCRIPTION
When I want to debug Jolie I usually need more launch options.
I was thinking others could have use for this