### PR TITLE
fix docker and commandparser url parsing that crashes installer.ol

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,19 +18,19 @@
 # To use this dockerfile locally, launch the following command from the root directory of your local copy of this repository.
 # docker build -f docker/Dockerfile -t jolielang/jolie .
 
-FROM maven:3-eclipse-temurin-21 as JolieBuild
+FROM maven:3-eclipse-temurin-21 AS jolie-build
 
 # Compile and install Jolie. We need it for running the release tools.
 COPY . /jolie-git
 WORKDIR /jolie-git
-RUN mvn -T 1C -Dmaven.test.skip -DskipTests -Dpmd.skip=true -pl '!test' clean install
+RUN mvn -B -T 1C -Dmaven.test.skip -DskipTests -Dpmd.skip=true -pl '!test' clean install
 RUN cp -avr /jolie-git/dist/jolie/ /usr/lib/jolie/
 RUN cp -a /jolie-git/dist/launchers/unix/.  /usr/bin/
-ENV JOLIE_HOME /usr/lib/jolie
+ENV JOLIE_HOME="/usr/lib/jolie"
 
 # Compile the Jolie installer
 WORKDIR /jolie-git/release-tools/installer
-RUN mvn -T 1C -Dmaven.test.skip -DskipTests -Dpmd.skip=true clean install
+RUN mvn -B -T 1C -Dmaven.test.skip -DskipTests -Dpmd.skip=true clean install
 
 # Use the release tools to generate jolie-installer.jar
 RUN apt-get update && apt-get install -y zip
@@ -41,7 +41,7 @@ RUN jolie release.ol ..
 FROM eclipse-temurin:21-jre
 WORKDIR /
 COPY --from=JolieBuild /jolie-git/release-tools/release/jolie-installer.jar .
-RUN apt-get update && apt-get install -y unzip \
-    && java -jar jolie-installer.jar -jh /usr/lib/jolie -jl /usr/bin \
+RUN apt-get update && apt-get install -y unzip
+RUN java -jar jolie-installer.jar -jh /usr/lib/jolie -jl /usr/bin \
     && rm jolie-installer.jar && rm -rf /tmp/*
-ENV JOLIE_HOME /usr/lib/jolie
+ENV JOLIE_HOME="/usr/lib/jolie"

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -18,19 +18,19 @@
 # To use this dockerfile locally, launch the following command from the root directory of your local copy of this repository.
 # docker build -f docker/Dockerfile.alpine -t jolielang/jolie .
 
-FROM maven:3-eclipse-temurin-21 as JolieBuild
+FROM maven:3-eclipse-temurin-21 AS jolie-build
 
 # Compile and install Jolie. We need it for running the release tools.
 COPY . /jolie-git
 WORKDIR /jolie-git
-RUN mvn -T 1C -Dmaven.test.skip -DskipTests -Dpmd.skip=true -pl '!test' clean install
+RUN mvn -B -T 1C -Dmaven.test.skip -DskipTests -Dpmd.skip=true -pl '!test' clean install
 RUN cp -avr /jolie-git/dist/jolie/ /usr/lib/jolie/
 RUN cp -a /jolie-git/dist/launchers/unix/.  /usr/bin/
-ENV JOLIE_HOME /usr/lib/jolie
+ENV JOLIE_HOME="/usr/lib/jolie"
 
 # Compile the Jolie installer
 WORKDIR /jolie-git/release-tools/installer
-RUN mvn -T 1C -Dmaven.test.skip -DskipTests -Dpmd.skip=true clean install
+RUN mvn -B -T 1C -Dmaven.test.skip -DskipTests -Dpmd.skip=true clean install
 
 # Use the release tools to generate jolie-installer.jar
 RUN apt-get update && apt-get install -y zip
@@ -41,7 +41,7 @@ RUN jolie release.ol ..
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /
 COPY --from=JolieBuild /jolie-git/release-tools/release/jolie-installer.jar .
-RUN apk add --update zip \
-    && java -jar jolie-installer.jar -jh /usr/lib/jolie -jl /usr/bin \
+RUN apk add --update zip
+RUN java -jar jolie-installer.jar -jh /usr/lib/jolie -jl /usr/bin \
     && rm jolie-installer.jar && rm -rf /tmp/*
-ENV JOLIE_HOME /usr/lib/jolie
+ENV JOLIE_HOME="/usr/lib/jolie"

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -18,19 +18,19 @@
 # To use this dockerfile locally, launch the following command from the root directory of your local copy of this repository.
 # docker build -f docker/Dockerfile.dev -t jolielang/jolie .
 
-FROM maven:3-eclipse-temurin-21 as JolieBuild
+FROM maven:3-eclipse-temurin-21 AS jolie-build
 
 # Compile and install Jolie. We need it for running the release tools.
 COPY . /jolie-git
 WORKDIR /jolie-git
-RUN mvn -T 1C -Dmaven.test.skip -DskipTests -Dpmd.skip=true -pl '!test' clean install
+RUN mvn -B -T 1C -Dmaven.test.skip -DskipTests -Dpmd.skip=true -pl '!test' clean install
 RUN cp -avr /jolie-git/dist/jolie/ /usr/lib/jolie/
 RUN cp -a /jolie-git/dist/launchers/unix/.  /usr/bin/
-ENV JOLIE_HOME /usr/lib/jolie
+ENV JOLIE_HOME="/usr/lib/jolie"
 
 # Compile the Jolie installer
 WORKDIR /jolie-git/release-tools/installer
-RUN mvn -T 1C -Dmaven.test.skip -DskipTests -Dpmd.skip=true clean install
+RUN mvn -B -T 1C -Dmaven.test.skip -DskipTests -Dpmd.skip=true clean install
 
 # Use the release tools to generate jolie-installer.jar
 RUN apt-get update && apt-get install -y zip
@@ -41,10 +41,10 @@ RUN jolie release.ol ..
 FROM maven:3-eclipse-temurin-21
 WORKDIR /
 COPY --from=JolieBuild /jolie-git/release-tools/release/jolie-installer.jar .
-RUN apt-get update && apt-get install -y unzip \
-    && java -jar jolie-installer.jar -jh /usr/lib/jolie -jl /usr/bin \
+RUN apt-get update && apt-get install -y unzip
+RUN java -jar jolie-installer.jar -jh /usr/lib/jolie -jl /usr/bin \
     && rm jolie-installer.jar && rm -rf /tmp/*
-ENV JOLIE_HOME /usr/lib/jolie
+ENV JOLIE_HOME="/usr/lib/jolie"
 
 # Setup a sudoer user account for development
 RUN apt-get install -y sudo \

--- a/docker/Dockerfile.jocker
+++ b/docker/Dockerfile.jocker
@@ -35,4 +35,4 @@ RUN cp /usr/lib/jni/libunix-java.so /usr/lib64/libmatthew-java
 
 WORKDIR /jocker
 
-CMD jolie --trace --responseTimeout 30000 dockerAPI.ol
+CMD ["jolie", "--trace", "--responseTimeout", "30000", "dockerAPI.ol"]

--- a/jolie-cli/src/main/java/jolie/cli/CommandLineParser.java
+++ b/jolie-cli/src/main/java/jolie/cli/CommandLineParser.java
@@ -565,7 +565,7 @@ public class CommandLineParser implements AutoCloseable {
 					urls.add( URI.create( "jap:file:" + path + "!/" ).toURL() );
 				}
 			} else if( new File( path ).isDirectory() ) {
-				urls.add( URI.create( "file:" + path + "/" ).toURL() );
+				urls.add( new File( path ).toURI().toURL() );
 			} else if( path.endsWith( "/*" ) ) {
 				final String pp = path;
 				String dirStr = Helpers.ifWindowsOrElse( () -> {

--- a/release-tools/installer/src/main/java/jolie/installer/Installer.java
+++ b/release-tools/installer/src/main/java/jolie/installer/Installer.java
@@ -179,7 +179,7 @@ public class Installer {
 		}
 	}
 	
-	private void runCmd( String cmd ) throws InterruptedException {
+	private int runCmd( String cmd ) throws InterruptedException {
 
 	try {
 		String line;
@@ -245,14 +245,15 @@ public class Installer {
 			}
 		});
 
-		process.waitFor();
+		int code = process.waitFor();
 		e1.shutdown();
 		e2.shutdown();
 		e3.shutdown();
 		process.destroy();
-
+		return code;
 	} catch (IOException err) {
 //		err.printStackTrace();
+		return 1;
 		}
 	}
 	
@@ -333,7 +334,7 @@ public class Installer {
 		}
 	}
 	
-	private void runJolie( String wdir, String jolieDir, String[] args ){
+	private int runJolie( String wdir, String jolieDir, String[] args ){
 //		String ext = "";
 //		String replaceVar;
 		
@@ -354,18 +355,20 @@ public class Installer {
 			} catch ( IllegalArgumentException iae ) {
 				System.err.println( "Error: Bad arguments: " + iae.getMessage() );
 				System.exit(1);
+				return 1;
 			}
 
 			cmd += " " + wdir + File.separator + "installer.ol " + os + " " + arguments;
 
-			runCmd( cmd );
+			return runCmd( cmd );
 			
 		} catch (InterruptedException ex) {
 			ex.printStackTrace();
+			return 2;
 		}
 	}
 		
-	public void run(String[] args)
+	public int run(String[] args)
 		throws IOException, InterruptedException,
 		ClassNotFoundException, NoSuchMethodException,
 		IllegalAccessException, InvocationTargetException, Exception
@@ -374,7 +377,7 @@ public class Installer {
 		String jolieDir = new File( tmp, "jolie" ).getAbsolutePath();
 		char fs = File.separatorChar;
 
-		runJolie( tmp.getParent(), jolieDir, args );
+		return runJolie( tmp.getParent(), jolieDir, args );
 
 //		URL[] urls = new URL[] { new URL( "file:" + jolieDir + fs + "jolie.jar" ), new URL( "file:" + jolieDir + fs + "lib" + fs + "libjolie.jar" ) };
 //		ClassLoader cl = new URLClassLoader( urls, Installer.class.getClassLoader() );

--- a/release-tools/installer/src/main/java/jolie/installer/JolieInstaller.java
+++ b/release-tools/installer/src/main/java/jolie/installer/JolieInstaller.java
@@ -30,10 +30,11 @@ public class JolieInstaller
 	public static void main( String[] args ) throws Exception
 	{
 		try {
-			new Installer().run(args);
-			System.exit(0); // installer keeps hanging around after the sub process has been stopped?
+			int code = new Installer().run(args);
+			System.exit(code); // installer keeps hanging around after the sub process has been stopped?
 		} catch( Exception e ) {
 			e.printStackTrace();
+			System.exit(1);
 		}
 	}
 }


### PR DESCRIPTION
- Follow Docker standard styling conventions
- Run Maven in batch mode
- Separate the RUN command during Jolie installation for better observability
- Ensure the installer returns a non-zero exit code on failure
- Fix a command parser line that was crashing the installer
