### PR TITLE
PATHS/VALUES w/ WHERE & $ + has operator

### DIFF
--- a/extensions/sodep/src/main/java/jolie/net/SodepProtocol.java
+++ b/extensions/sodep/src/main/java/jolie/net/SodepProtocol.java
@@ -41,6 +41,7 @@ import jolie.net.protocols.ConcurrentCommProtocol;
 import jolie.runtime.ByteArray;
 import jolie.runtime.FaultException;
 import jolie.runtime.Value;
+import jolie.runtime.ValuePath;
 import jolie.runtime.ValueVector;
 import jolie.runtime.VariablePath;
 
@@ -125,6 +126,9 @@ public class SodepProtocol extends ConcurrentCommProtocol {
 		} else if( valueObject instanceof String ) {
 			out.writeByte( DataTypeHeaderId.STRING );
 			writeString( out, (String) valueObject );
+		} else if( valueObject instanceof ValuePath ) {
+			out.writeByte( DataTypeHeaderId.STRING );
+			writeString( out, ((ValuePath) valueObject).getPath() );
 		} else if( valueObject instanceof Integer ) {
 			out.writeByte( DataTypeHeaderId.INT );
 			out.writeInt( (Integer) valueObject );

--- a/jolie/pom.xml
+++ b/jolie/pom.xml
@@ -60,6 +60,11 @@
 			<version>${jolie.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>RELEASE</version>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>

--- a/jolie/src/main/java/jolie/OOITBuilder.java
+++ b/jolie/src/main/java/jolie/OOITBuilder.java
@@ -1446,15 +1446,10 @@ public class OOITBuilder implements UnitOLVisitor {
 	private record PathQueryComponents(VariablePath varPath, List< PathOperation > remainingOps, Expression whereExpr) {
 	}
 
-	private PathQueryComponents buildPathQuery( List< PathOperation > operations, OLSyntaxNode whereClause,
-		String exprType ) {
+	private PathQueryComponents buildPathQuery( List< PathOperation > operations, OLSyntaxNode whereClause ) {
 		// Extract identifier from first operation (always Field)
-		if( operations.isEmpty() )
-			throw new IllegalStateException( exprType + " expression must have at least one operation" );
-
-		PathOperation first = operations.get( 0 );
-		if( !(first instanceof PathOperation.Field fieldOp) )
-			throw new IllegalStateException( "First operation must be Field, got: " + first.getClass() );
+		// The parser (parsePathOperations) guarantees operations is non-empty and first is Field
+		PathOperation.Field fieldOp = (PathOperation.Field) operations.get( 0 );
 
 		// Build VariablePath from identifier
 		// For a simple identifier like "data", the VariablePath is: [(key: "data", index: 0)]
@@ -1476,13 +1471,13 @@ public class OOITBuilder implements UnitOLVisitor {
 
 	@Override
 	public void visit( PathsExpressionNode n ) {
-		PathQueryComponents pqc = buildPathQuery( n.operations(), n.whereClause(), "PATHS" );
+		PathQueryComponents pqc = buildPathQuery( n.operations(), n.whereClause() );
 		currExpression = new jolie.runtime.expression.PathsExpression( pqc.varPath, pqc.remainingOps, pqc.whereExpr );
 	}
 
 	@Override
 	public void visit( ValuesExpressionNode n ) {
-		PathQueryComponents pqc = buildPathQuery( n.operations(), n.whereClause(), "VALUES" );
+		PathQueryComponents pqc = buildPathQuery( n.operations(), n.whereClause() );
 		currExpression = new jolie.runtime.expression.ValuesExpression( pqc.varPath, pqc.remainingOps, pqc.whereExpr );
 	}
 

--- a/jolie/src/main/java/jolie/OOITBuilder.java
+++ b/jolie/src/main/java/jolie/OOITBuilder.java
@@ -214,6 +214,7 @@ import jolie.runtime.expression.CastDoubleExpression;
 import jolie.runtime.expression.CastIntExpression;
 import jolie.runtime.expression.CastLongExpression;
 import jolie.runtime.expression.CastStringExpression;
+import jolie.runtime.expression.CurrentValueExpression;
 import jolie.runtime.expression.CompareCondition;
 import jolie.runtime.expression.Expression;
 import jolie.runtime.expression.Expression.Operand;
@@ -1560,7 +1561,14 @@ public class OOITBuilder implements UnitOLVisitor {
 
 	@Override
 	public void visit( ValueVectorSizeExpressionNode n ) {
-		currExpression = new ValueVectorSizeExpression( buildVariablePath( n.variablePath() ) );
+		OLSyntaxNode exprNode = n.expression();
+		currExpression = switch( exprNode ) {
+		case VariablePathNode vpn -> new ValueVectorSizeExpression( buildVariablePath( vpn ) );
+		case CurrentValueNode cvn -> new ValueVectorSizeExpression(
+			(CurrentValueExpression) buildExpression( cvn ) );
+		default -> throw new IllegalStateException(
+			"Unexpected expression type in ValueVectorSizeExpressionNode: " + exprNode.getClass().getSimpleName() );
+		};
 	}
 
 	@Override

--- a/jolie/src/main/java/jolie/OOITBuilder.java
+++ b/jolie/src/main/java/jolie/OOITBuilder.java
@@ -85,6 +85,7 @@ import jolie.lang.parse.ast.OperationDeclaration;
 import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
+import jolie.lang.parse.ast.PvalAssignStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -174,6 +175,7 @@ import jolie.process.PostDecrementProcess;
 import jolie.process.PostIncrementProcess;
 import jolie.process.PreDecrementProcess;
 import jolie.process.PreIncrementProcess;
+import jolie.process.PvalAssignmentProcess;
 import jolie.process.Process;
 import jolie.process.ProvideUntilProcess;
 import jolie.process.RequestResponseProcess;
@@ -1486,6 +1488,17 @@ public class OOITBuilder implements UnitOLVisitor {
 	public void visit( PvalExpressionNode n ) {
 		n.pathExpression().accept( this );
 		currExpression = new jolie.runtime.expression.PvalExpression( currExpression, n.pathOperations(), n.context() );
+	}
+
+	@Override
+	public void visit( PvalAssignStatement n ) {
+		n.pathExpression().accept( this );
+		Expression pathExpr = currExpression;
+		n.expression().accept( this );
+		Expression valueExpr = currExpression;
+		PvalAssignmentProcess p = new PvalAssignmentProcess( pathExpr, n.pathOperations(), valueExpr, n.context() );
+		currProcess = p;
+		currExpression = p;
 	}
 
 	@Override

--- a/jolie/src/main/java/jolie/OOITBuilder.java
+++ b/jolie/src/main/java/jolie/OOITBuilder.java
@@ -86,6 +86,7 @@ import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
 import jolie.lang.parse.ast.PvalAssignStatement;
+import jolie.lang.parse.ast.PvalDeepCopyStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -176,6 +177,7 @@ import jolie.process.PostIncrementProcess;
 import jolie.process.PreDecrementProcess;
 import jolie.process.PreIncrementProcess;
 import jolie.process.PvalAssignmentProcess;
+import jolie.process.PvalDeepCopyProcess;
 import jolie.process.Process;
 import jolie.process.ProvideUntilProcess;
 import jolie.process.RequestResponseProcess;
@@ -1499,6 +1501,15 @@ public class OOITBuilder implements UnitOLVisitor {
 		PvalAssignmentProcess p = new PvalAssignmentProcess( pathExpr, n.pathOperations(), valueExpr, n.context() );
 		currProcess = p;
 		currExpression = p;
+	}
+
+	@Override
+	public void visit( PvalDeepCopyStatement n ) {
+		n.pathExpression().accept( this );
+		Expression pathExpr = currExpression;
+		n.rightExpression().accept( this );
+		Expression rightExpr = currExpression;
+		currProcess = new PvalDeepCopyProcess( pathExpr, n.pathOperations(), rightExpr, n.context() );
 	}
 
 	@Override

--- a/jolie/src/main/java/jolie/OOITBuilder.java
+++ b/jolie/src/main/java/jolie/OOITBuilder.java
@@ -129,6 +129,7 @@ import jolie.lang.parse.ast.expression.OrConditionNode;
 import jolie.lang.parse.ast.expression.PathOperation;
 import jolie.lang.parse.ast.expression.PathsExpressionNode;
 import jolie.lang.parse.ast.expression.ProductExpressionNode;
+import jolie.lang.parse.ast.expression.PvalExpressionNode;
 import jolie.lang.parse.ast.expression.SolicitResponseExpressionNode;
 import jolie.lang.parse.ast.expression.SumExpressionNode;
 import jolie.lang.parse.ast.expression.ValuesExpressionNode;
@@ -1479,6 +1480,12 @@ public class OOITBuilder implements UnitOLVisitor {
 	public void visit( ValuesExpressionNode n ) {
 		PathQueryComponents pqc = buildPathQuery( n.operations(), n.whereClause(), "VALUES" );
 		currExpression = new jolie.runtime.expression.ValuesExpression( pqc.varPath, pqc.remainingOps, pqc.whereExpr );
+	}
+
+	@Override
+	public void visit( PvalExpressionNode n ) {
+		n.pathExpression().accept( this );
+		currExpression = new jolie.runtime.expression.PvalExpression( currExpression, n.pathOperations(), n.context() );
 	}
 
 	@Override

--- a/jolie/src/main/java/jolie/process/PvalAssignmentProcess.java
+++ b/jolie/src/main/java/jolie/process/PvalAssignmentProcess.java
@@ -38,11 +38,7 @@ public class PvalAssignmentProcess implements Process, Expression {
 
 	@Override
 	public Expression cloneExpression( TransformationReason reason ) {
-		return new PvalAssignmentProcess(
-			pathExpression.cloneExpression( reason ),
-			pathOps,
-			expression.cloneExpression( reason ),
-			context );
+		return (Expression) copy( reason );
 	}
 
 	@Override

--- a/jolie/src/main/java/jolie/process/PvalAssignmentProcess.java
+++ b/jolie/src/main/java/jolie/process/PvalAssignmentProcess.java
@@ -1,0 +1,65 @@
+package jolie.process;
+
+import java.util.List;
+
+import jolie.lang.parse.ast.expression.PathOperation;
+import jolie.lang.parse.context.ParsingContext;
+import jolie.runtime.PvalHelper;
+import jolie.runtime.Value;
+import jolie.runtime.VariablePath;
+import jolie.runtime.expression.Expression;
+
+/**
+ * PVAL assignment (lvalue): assigns a value to the location specified by a path. Example:
+ * pval(res.results[0]).field = "newValue"
+ */
+public class PvalAssignmentProcess implements Process, Expression {
+	private final Expression pathExpression;
+	private final List< PathOperation > pathOps;
+	private final Expression expression;
+	private final ParsingContext context;
+
+	public PvalAssignmentProcess( Expression pathExpression, List< PathOperation > pathOps,
+		Expression expression, ParsingContext context ) {
+		this.pathExpression = pathExpression;
+		this.pathOps = pathOps;
+		this.expression = expression;
+		this.context = context;
+	}
+
+	@Override
+	public Process copy( TransformationReason reason ) {
+		return new PvalAssignmentProcess(
+			pathExpression.cloneExpression( reason ),
+			pathOps,
+			expression.cloneExpression( reason ),
+			context );
+	}
+
+	@Override
+	public Expression cloneExpression( TransformationReason reason ) {
+		return new PvalAssignmentProcess(
+			pathExpression.cloneExpression( reason ),
+			pathOps,
+			expression.cloneExpression( reason ),
+			context );
+	}
+
+	@Override
+	public void run() {
+		evaluate();
+	}
+
+	@Override
+	public Value evaluate() {
+		VariablePath varPath = PvalHelper.resolveVariablePath( pathExpression.evaluate(), pathOps, context );
+		Value val = varPath.getValue();
+		val.assignValue( expression.evaluate() );
+		return val;
+	}
+
+	@Override
+	public boolean isKillable() {
+		return true;
+	}
+}

--- a/jolie/src/main/java/jolie/process/PvalDeepCopyProcess.java
+++ b/jolie/src/main/java/jolie/process/PvalDeepCopyProcess.java
@@ -1,0 +1,49 @@
+package jolie.process;
+
+import java.util.List;
+import jolie.lang.parse.ast.expression.PathOperation;
+import jolie.lang.parse.context.ParsingContext;
+import jolie.runtime.PvalHelper;
+import jolie.runtime.Value;
+import jolie.runtime.VariablePath;
+import jolie.runtime.expression.Expression;
+
+public class PvalDeepCopyProcess implements Process {
+	private final Expression pathExpression;
+	private final List< PathOperation > pathOps;
+	private final Expression rightExpression;
+	private final ParsingContext context;
+
+	public PvalDeepCopyProcess( Expression pathExpression, List< PathOperation > pathOps,
+		Expression rightExpression, ParsingContext context ) {
+		this.pathExpression = pathExpression;
+		this.pathOps = pathOps;
+		this.rightExpression = rightExpression;
+		this.context = context;
+	}
+
+	@Override
+	public Process copy( TransformationReason reason ) {
+		return new PvalDeepCopyProcess(
+			pathExpression.cloneExpression( reason ),
+			pathOps,
+			rightExpression.cloneExpression( reason ),
+			context );
+	}
+
+	@Override
+	public void run() {
+		VariablePath leftPath = PvalHelper.resolveVariablePath( pathExpression.evaluate(), pathOps, context );
+		if( rightExpression instanceof VariablePath ) {
+			leftPath.deepCopy( (VariablePath) rightExpression );
+		} else {
+			Value targetValue = leftPath.getValue();
+			targetValue.deepCopy( rightExpression.evaluate() );
+		}
+	}
+
+	@Override
+	public boolean isKillable() {
+		return true;
+	}
+}

--- a/jolie/src/main/java/jolie/runtime/CompareOperators.java
+++ b/jolie/src/main/java/jolie/runtime/CompareOperators.java
@@ -77,4 +77,6 @@ public final class CompareOperators {
 				return (left.intValue() >= right.intValue());
 			}
 		};
+	public final static BiPredicate< Value, Value > HAS =
+		( left, right ) -> left.hasChildren( right.strValue() );
 }

--- a/jolie/src/main/java/jolie/runtime/PvalHelper.java
+++ b/jolie/src/main/java/jolie/runtime/PvalHelper.java
@@ -15,14 +15,14 @@ public final class PvalHelper {
 	 * Resolves a path value and optional path operations to a VariablePath. Throws TypeMismatch fault
 	 * if the value is not a path type.
 	 */
-	public static VariablePath resolveVariablePath( Value pathValue, List< PathOperation > pathOps,
+	public static VariablePath resolveVariablePath( Value value, List< PathOperation > pathOps,
 		ParsingContext context ) {
-		if( !pathValue.isPath() ) {
+		if( !value.isPath() ) {
 			throw new FaultException( "TypeMismatch",
-				"pval requires a path type value, got: " + pathValue.strValue(), context )
+				"pval requires a path type value, got: " + value.strValue(), context )
 				.toRuntimeFaultException();
 		}
-		String pathStr = pathValue.pathValue().getPath();
+		String pathStr = value.pathValue().getPath();
 		String fullPathStr = pathStr + pathOpsToString( pathOps );
 		return parsePathString( fullPathStr );
 	}

--- a/jolie/src/main/java/jolie/runtime/PvalHelper.java
+++ b/jolie/src/main/java/jolie/runtime/PvalHelper.java
@@ -43,9 +43,10 @@ public final class PvalHelper {
 	}
 
 	/**
-	 * Parses a path string like "data[1].field[2].subfield" into a VariablePath.
+	 * Parses a path string like "data[1].field[2].subfield" into a VariablePath. Throws
+	 * IllegalArgumentException if the path format is invalid.
 	 */
-	private static VariablePath parsePathString( String pathStr ) {
+	public static VariablePath parsePathString( String pathStr ) {
 		VariablePathBuilder b = new VariablePathBuilder( false );
 		for( String s : pathStr.split( "\\." ) ) {
 			int i = s.indexOf( '[' );

--- a/jolie/src/main/java/jolie/runtime/PvalHelper.java
+++ b/jolie/src/main/java/jolie/runtime/PvalHelper.java
@@ -1,0 +1,59 @@
+package jolie.runtime;
+
+import java.util.List;
+
+import jolie.lang.parse.ast.expression.PathOperation;
+import jolie.lang.parse.context.ParsingContext;
+
+/**
+ * Shared utilities for pval operations (both rvalue and lvalue).
+ */
+public final class PvalHelper {
+	private PvalHelper() {}
+
+	/**
+	 * Resolves a path value and optional path operations to a VariablePath. Throws TypeMismatch fault
+	 * if the value is not a path type.
+	 */
+	public static VariablePath resolveVariablePath( Value pathValue, List< PathOperation > pathOps,
+		ParsingContext context ) {
+		if( !pathValue.isPath() ) {
+			throw new FaultException( "TypeMismatch",
+				"pval requires a path type value, got: " + pathValue.strValue(), context )
+				.toRuntimeFaultException();
+		}
+		String pathStr = pathValue.pathValue().getPath();
+		String fullPathStr = pathStr + pathOpsToString( pathOps );
+		return parsePathString( fullPathStr );
+	}
+
+	/**
+	 * Converts path operations to a string suffix (e.g., ".child[0].name").
+	 */
+	private static String pathOpsToString( List< PathOperation > ops ) {
+		StringBuilder sb = new StringBuilder();
+		for( PathOperation op : ops ) {
+			switch( op ) {
+			case PathOperation.Field(String name) -> sb.append( "." ).append( name );
+			case PathOperation.ArrayIndex(var idx) -> sb.append( "[" ).append( idx.intValue() ).append( "]" );
+			default -> throw new IllegalArgumentException( "Unsupported path operation in pval: " + op );
+			}
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Parses a path string like "data[1].field[2].subfield" into a VariablePath.
+	 */
+	private static VariablePath parsePathString( String pathStr ) {
+		VariablePathBuilder b = new VariablePathBuilder( false );
+		for( String s : pathStr.split( "\\." ) ) {
+			int i = s.indexOf( '[' );
+			if( i < 0 )
+				b.add( s );
+			else
+				b.add( s.substring( 0, i ), Integer.parseInt( s.substring( i + 1, s.length() - 1 ) ) );
+		}
+		return b.toVariablePath();
+	}
+}

--- a/jolie/src/main/java/jolie/runtime/Value.java
+++ b/jolie/src/main/java/jolie/runtime/Value.java
@@ -680,7 +680,7 @@ public abstract class Value implements Expression, Cloneable {
 		try {
 			return pathValueStrict();
 		} catch( TypeCastingException e ) {
-			return new ValuePath( "" );
+			return new ValuePath( "", false );
 		}
 	}
 
@@ -692,7 +692,12 @@ public abstract class Value implements Expression, Cloneable {
 		} else if( o instanceof ValuePath ) {
 			return (ValuePath) o;
 		} else if( o instanceof String ) {
-			return new ValuePath( (String) o );
+			try {
+				return new ValuePath( (String) o, true );
+			} catch( IllegalArgumentException e ) {
+				// ValuePath constructor validates path format; convert to expected exception type
+				throw new TypeCastingException();
+			}
 		}
 		throw new TypeCastingException();
 	}

--- a/jolie/src/main/java/jolie/runtime/Value.java
+++ b/jolie/src/main/java/jolie/runtime/Value.java
@@ -387,6 +387,10 @@ public abstract class Value implements Expression, Cloneable {
 		return new ValueImpl( b );
 	}
 
+	public static Value create( ValuePath p ) {
+		return new ValueImpl( p );
+	}
+
 	public static Value create( Value value ) {
 		return new ValueImpl( value );
 	}
@@ -505,6 +509,10 @@ public abstract class Value implements Expression, Cloneable {
 		setValueObject( object );
 	}
 
+	public final void setValue( ValuePath object ) {
+		setValueObject( object );
+	}
+
 	@Override
 	public final synchronized boolean equals( Object obj ) {
 		if( !(obj instanceof Value) )
@@ -515,6 +523,8 @@ public abstract class Value implements Expression, Cloneable {
 		if( val.isDefined() ) {
 			if( isByteArray() || val.isByteArray() ) {
 				r = byteArrayValue().equals( val.byteArrayValue() );
+			} else if( isPath() || val.isPath() ) {
+				r = pathValue().equals( val.pathValue() );
 			} else if( isString() || val.isString() ) {
 				r = strValue().equals( val.strValue() );
 			} else if( isDouble() || val.isDouble() ) {
@@ -563,6 +573,10 @@ public abstract class Value implements Expression, Cloneable {
 
 	public final boolean isString() {
 		return (valueObject() instanceof String);
+	}
+
+	public final boolean isPath() {
+		return (valueObject() instanceof ValuePath);
 	}
 
 	public final boolean isChannel() {
@@ -660,6 +674,27 @@ public abstract class Value implements Expression, Cloneable {
 			}
 		}
 		return r;
+	}
+
+	public ValuePath pathValue() {
+		try {
+			return pathValueStrict();
+		} catch( TypeCastingException e ) {
+			return new ValuePath( "" );
+		}
+	}
+
+	public final ValuePath pathValueStrict()
+		throws TypeCastingException {
+		Object o = valueObject();
+		if( o == null ) {
+			throw new TypeCastingException();
+		} else if( o instanceof ValuePath ) {
+			return (ValuePath) o;
+		} else if( o instanceof String ) {
+			return new ValuePath( (String) o );
+		}
+		throw new TypeCastingException();
 	}
 
 	public int intValue() {

--- a/jolie/src/main/java/jolie/runtime/ValuePath.java
+++ b/jolie/src/main/java/jolie/runtime/ValuePath.java
@@ -7,7 +7,18 @@ package jolie.runtime;
 public class ValuePath {
 	private final String path;
 
-	public ValuePath( String path ) {
+	/**
+	 * Creates a ValuePath from a path string.
+	 *
+	 * @param path the path string
+	 * @param validate if true, validates the path format; if false, assumes path is already valid (use
+	 *        false only with known-valid paths for performance)
+	 * @throws IllegalArgumentException if validate is true and the path format is invalid
+	 */
+	public ValuePath( String path, boolean validate ) {
+		if( validate ) {
+			PvalHelper.parsePathString( path ); // Validates format
+		}
 		this.path = path;
 	}
 

--- a/jolie/src/main/java/jolie/runtime/ValuePath.java
+++ b/jolie/src/main/java/jolie/runtime/ValuePath.java
@@ -1,0 +1,34 @@
+package jolie.runtime;
+
+/**
+ * Represents a path to a value in a Jolie data structure. Examples: "data[0]",
+ * "tree.field[2].subfield"
+ */
+public class ValuePath {
+	private final String path;
+
+	public ValuePath( String path ) {
+		this.path = path;
+	}
+
+	public String getPath() {
+		return path;
+	}
+
+	@Override
+	public boolean equals( Object other ) {
+		if( !(other instanceof ValuePath) )
+			return false;
+		return path.equals( ((ValuePath) other).path );
+	}
+
+	@Override
+	public int hashCode() {
+		return path.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return path;
+	}
+}

--- a/jolie/src/main/java/jolie/runtime/VariablePathBuilder.java
+++ b/jolie/src/main/java/jolie/runtime/VariablePathBuilder.java
@@ -44,6 +44,11 @@ public final class VariablePathBuilder {
 		return this;
 	}
 
+	public VariablePathBuilder add( String id ) {
+		list.add( new Pair<>( Value.create( id ), null ) );
+		return this;
+	}
+
 	@SuppressWarnings( "unchecked" )
 	public VariablePath toVariablePath() {
 		if( global ) {

--- a/jolie/src/main/java/jolie/runtime/expression/AndCondition.java
+++ b/jolie/src/main/java/jolie/runtime/expression/AndCondition.java
@@ -35,7 +35,7 @@ import jolie.runtime.Value;
  * @see Condition
  */
 public class AndCondition implements Expression {
-	private final Expression[] children;
+	public final Expression[] children;
 
 	/** Constructor */
 	public AndCondition( Expression[] children ) {

--- a/jolie/src/main/java/jolie/runtime/expression/Candidate.java
+++ b/jolie/src/main/java/jolie/runtime/expression/Candidate.java
@@ -1,0 +1,16 @@
+package jolie.runtime.expression;
+
+import jolie.runtime.Value;
+import jolie.runtime.ValueVector;
+import com.google.common.primitives.UnsignedInteger;
+
+record Candidate(ValueVector vector, UnsignedInteger index, String path) {
+
+	Candidate( ValueVector vector, String path ) {
+		this( vector, UnsignedInteger.ZERO, path );
+	}
+
+	Value value() {
+		return vector.get( index.intValue() );
+	}
+}

--- a/jolie/src/main/java/jolie/runtime/expression/Candidate.java
+++ b/jolie/src/main/java/jolie/runtime/expression/Candidate.java
@@ -4,6 +4,11 @@ import jolie.runtime.Value;
 import jolie.runtime.ValueVector;
 import com.google.common.primitives.UnsignedInteger;
 
+/**
+ * Represents a value location during PATHS/VALUES traversal. All values are uniformly represented
+ * as vector[index], exploiting Jolie's a = a[0] equivalence. The path accumulates the traversal
+ * route (e.g., "data[0].child[2]") for PATHS result generation.
+ */
 record Candidate(ValueVector vector, UnsignedInteger index, String path) {
 
 	Candidate( ValueVector vector, String path ) {

--- a/jolie/src/main/java/jolie/runtime/expression/CompareCondition.java
+++ b/jolie/src/main/java/jolie/runtime/expression/CompareCondition.java
@@ -33,7 +33,7 @@ import jolie.runtime.Value;
  *
  */
 public class CompareCondition implements Expression {
-	private final Expression leftExpression, rightExpression;
+	public final Expression leftExpression, rightExpression;
 	private final BiPredicate< Value, Value > compareOperator;
 
 	public CompareCondition( Expression left, Expression right, BiPredicate< Value, Value > compareOperator ) {

--- a/jolie/src/main/java/jolie/runtime/expression/CurrentValueExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/CurrentValueExpression.java
@@ -18,6 +18,10 @@ public class CurrentValueExpression implements Expression {
 		this.operations = operations;
 	}
 
+	/**
+	 * Called by WhereEvaluator.bind() to set the current value that $ refers to during WHERE
+	 * evaluation. This is updated dynamically as different candidates are tested.
+	 */
 	public void setCurrentCandidate( Candidate candidate ) {
 		this.currentCandidate = Objects.requireNonNull( candidate, "$ cannot be null" );
 	}

--- a/jolie/src/main/java/jolie/runtime/expression/CurrentValueExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/CurrentValueExpression.java
@@ -1,0 +1,34 @@
+package jolie.runtime.expression;
+
+import jolie.lang.parse.ast.expression.PathOperation;
+import jolie.process.TransformationReason;
+import jolie.runtime.Value;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents $ with optional path navigation. Returns single value or multi-values (in .results)
+ * for existential evaluation.
+ */
+public class CurrentValueExpression implements Expression {
+	public Candidate currentCandidate;
+	public final List< PathOperation > operations;
+
+	public CurrentValueExpression( List< PathOperation > operations ) {
+		this.operations = operations;
+	}
+
+	public void setCurrentCandidate( Candidate candidate ) {
+		this.currentCandidate = Objects.requireNonNull( candidate, "$ cannot be null" );
+	}
+
+	@Override
+	public Expression cloneExpression( TransformationReason reason ) {
+		return new CurrentValueExpression( operations );
+	}
+
+	@Override
+	public Value evaluate() {
+		return currentCandidate.value();
+	}
+}

--- a/jolie/src/main/java/jolie/runtime/expression/NotExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/NotExpression.java
@@ -26,7 +26,7 @@ import jolie.process.TransformationReason;
 import jolie.runtime.Value;
 
 public class NotExpression implements Expression {
-	private final Expression expression;
+	public final Expression expression;
 
 	public NotExpression( Expression expression ) {
 		this.expression = expression;

--- a/jolie/src/main/java/jolie/runtime/expression/OrCondition.java
+++ b/jolie/src/main/java/jolie/runtime/expression/OrCondition.java
@@ -27,7 +27,7 @@ import jolie.process.TransformationReason;
 import jolie.runtime.Value;
 
 public class OrCondition implements Expression {
-	final private Expression[] children;
+	public final Expression[] children;
 
 	public OrCondition( Expression[] children ) {
 		this.children = children;

--- a/jolie/src/main/java/jolie/runtime/expression/PathsExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/PathsExpression.java
@@ -3,12 +3,13 @@ package jolie.runtime.expression;
 import jolie.lang.parse.ast.expression.PathOperation;
 import jolie.process.TransformationReason;
 import jolie.runtime.Value;
+import jolie.runtime.ValuePath;
 import jolie.runtime.VariablePath;
 import java.util.List;
 
 /**
- * PATHS expression: returns path strings matching pattern and WHERE filter. Example: paths data[*]
- * where $ > 5 → ["data[0]", "data[2]"]
+ * PATHS expression: returns path values matching pattern and WHERE filter. Example: paths data[*]
+ * where $ > 5 → path values for ["data[0]", "data[2]"]
  */
 public class PathsExpression implements Expression {
 	private final VariablePath path;
@@ -38,7 +39,7 @@ public class PathsExpression implements Expression {
 		for( Candidate c : ValueNavigator.navigate( path, ops ) ) {
 			if( WhereEvaluator.matches( where, c ) ) {
 				int index = result.getChildren( "results" ).size();
-				result.getChildren( "results" ).get( index ).setValue( c.path() );
+				result.getChildren( "results" ).get( index ).setValue( new ValuePath( c.path() ) );
 			}
 		}
 		return result;

--- a/jolie/src/main/java/jolie/runtime/expression/PathsExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/PathsExpression.java
@@ -1,0 +1,46 @@
+package jolie.runtime.expression;
+
+import jolie.lang.parse.ast.expression.PathOperation;
+import jolie.process.TransformationReason;
+import jolie.runtime.Value;
+import jolie.runtime.VariablePath;
+import java.util.List;
+
+/**
+ * PATHS expression: returns path strings matching pattern and WHERE filter. Example: paths data[*]
+ * where $ > 5 → ["data[0]", "data[2]"]
+ */
+public class PathsExpression implements Expression {
+	private final VariablePath path;
+	private final List< PathOperation > ops;
+	private final Expression where;
+
+	public PathsExpression(
+		VariablePath path,
+		List< PathOperation > ops,
+		Expression where ) {
+		this.path = path;
+		this.ops = ops;
+		this.where = where;
+	}
+
+	@Override
+	public Expression cloneExpression( TransformationReason reason ) {
+		return new PathsExpression(
+			(VariablePath) path.cloneExpression( reason ),
+			ops,
+			where.cloneExpression( reason ) );
+	}
+
+	@Override
+	public Value evaluate() {
+		Value result = Value.create();
+		for( Candidate c : ValueNavigator.navigate( path, ops ) ) {
+			if( WhereEvaluator.matches( where, c ) ) {
+				int index = result.getChildren( "results" ).size();
+				result.getChildren( "results" ).get( index ).setValue( c.path() );
+			}
+		}
+		return result;
+	}
+}

--- a/jolie/src/main/java/jolie/runtime/expression/PathsExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/PathsExpression.java
@@ -39,7 +39,7 @@ public class PathsExpression implements Expression {
 		for( Candidate c : ValueNavigator.navigate( path, ops ) ) {
 			if( WhereEvaluator.matches( where, c ) ) {
 				int index = result.getChildren( "results" ).size();
-				result.getChildren( "results" ).get( index ).setValue( new ValuePath( c.path() ) );
+				result.getChildren( "results" ).get( index ).setValue( new ValuePath( c.path(), false ) );
 			}
 		}
 		return result;

--- a/jolie/src/main/java/jolie/runtime/expression/ProductExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/ProductExpression.java
@@ -27,7 +27,7 @@ import jolie.runtime.FaultException;
 import jolie.runtime.Value;
 
 public class ProductExpression implements Expression {
-	private final Operand[] children;
+	final Operand[] children;
 	private final ParsingContext context;
 
 	public ProductExpression( Operand[] children, ParsingContext context ) {

--- a/jolie/src/main/java/jolie/runtime/expression/PvalExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/PvalExpression.java
@@ -1,19 +1,17 @@
 package jolie.runtime.expression;
 
+import java.util.List;
+
 import jolie.lang.parse.ast.expression.PathOperation;
 import jolie.lang.parse.context.ParsingContext;
 import jolie.process.TransformationReason;
-import jolie.runtime.FaultException;
+import jolie.runtime.PvalHelper;
 import jolie.runtime.Value;
 import jolie.runtime.VariablePath;
-import jolie.runtime.VariablePathBuilder;
-
-import java.util.List;
 
 /**
- * PVAL expression: dereferences a path value to get a reference to the actual value. Example:
- * pval(res.results[0]).field The path expression must evaluate to a path type. Optional path
- * operations extend the base path.
+ * PVAL expression (rvalue): dereferences a path value to get a reference to the actual value.
+ * Example: pval(res.results[0]).field
  */
 public class PvalExpression implements Expression {
 	private final Expression pathExpression;
@@ -33,52 +31,7 @@ public class PvalExpression implements Expression {
 
 	@Override
 	public Value evaluate() {
-		Value pathValue = pathExpression.evaluate();
-
-		// pval requires a path type value
-		if( !pathValue.isPath() ) {
-			throw new FaultException( "TypeMismatch",
-				"pval requires a path type value, got: " + pathValue.strValue(), context )
-				.toRuntimeFaultException();
-		}
-
-		String pathStr = pathValue.pathValue().getPath();
-
-		// Extend path string with additional operations
-		String fullPathStr = pathStr + pathOpsToString( pathOps );
-
-		// Convert to VariablePath and return link
-		VariablePath fullPath = parsePathString( fullPathStr );
+		VariablePath fullPath = PvalHelper.resolveVariablePath( pathExpression.evaluate(), pathOps, context );
 		return Value.createLink( fullPath );
-	}
-
-	/**
-	 * Converts path operations to a path string suffix (e.g., ".child[0].name").
-	 */
-	private String pathOpsToString( List< PathOperation > ops ) {
-		StringBuilder sb = new StringBuilder();
-		for( PathOperation op : ops ) {
-			switch( op ) {
-			case PathOperation.Field(String name) -> sb.append( "." ).append( name );
-			case PathOperation.ArrayIndex(var idx) -> sb.append( "[" ).append( idx.intValue() ).append( "]" );
-			default -> throw new IllegalArgumentException( "Unsupported path operation in pval: " + op );
-			}
-		}
-		return sb.toString();
-	}
-
-	/**
-	 * Parses a path string like "data[1].field[2].subfield" into a VariablePath.
-	 */
-	private VariablePath parsePathString( String pathStr ) {
-		VariablePathBuilder b = new VariablePathBuilder( false );
-		for( String s : pathStr.split( "\\." ) ) {
-			int i = s.indexOf( '[' );
-			if( i < 0 )
-				b.add( s );
-			else
-				b.add( s.substring( 0, i ), Integer.parseInt( s.substring( i + 1, s.length() - 1 ) ) );
-		}
-		return b.toVariablePath();
 	}
 }

--- a/jolie/src/main/java/jolie/runtime/expression/PvalExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/PvalExpression.java
@@ -1,0 +1,84 @@
+package jolie.runtime.expression;
+
+import jolie.lang.parse.ast.expression.PathOperation;
+import jolie.lang.parse.context.ParsingContext;
+import jolie.process.TransformationReason;
+import jolie.runtime.FaultException;
+import jolie.runtime.Value;
+import jolie.runtime.VariablePath;
+import jolie.runtime.VariablePathBuilder;
+
+import java.util.List;
+
+/**
+ * PVAL expression: dereferences a path value to get a reference to the actual value. Example:
+ * pval(res.results[0]).field The path expression must evaluate to a path type. Optional path
+ * operations extend the base path.
+ */
+public class PvalExpression implements Expression {
+	private final Expression pathExpression;
+	private final List< PathOperation > pathOps;
+	private final ParsingContext context;
+
+	public PvalExpression( Expression pathExpression, List< PathOperation > pathOps, ParsingContext context ) {
+		this.pathExpression = pathExpression;
+		this.pathOps = pathOps;
+		this.context = context;
+	}
+
+	@Override
+	public Expression cloneExpression( TransformationReason reason ) {
+		return new PvalExpression( pathExpression.cloneExpression( reason ), pathOps, context );
+	}
+
+	@Override
+	public Value evaluate() {
+		Value pathValue = pathExpression.evaluate();
+
+		// pval requires a path type value
+		if( !pathValue.isPath() ) {
+			throw new FaultException( "TypeMismatch",
+				"pval requires a path type value, got: " + pathValue.strValue(), context )
+				.toRuntimeFaultException();
+		}
+
+		String pathStr = pathValue.pathValue().getPath();
+
+		// Extend path string with additional operations
+		String fullPathStr = pathStr + pathOpsToString( pathOps );
+
+		// Convert to VariablePath and return link
+		VariablePath fullPath = parsePathString( fullPathStr );
+		return Value.createLink( fullPath );
+	}
+
+	/**
+	 * Converts path operations to a path string suffix (e.g., ".child[0].name").
+	 */
+	private String pathOpsToString( List< PathOperation > ops ) {
+		StringBuilder sb = new StringBuilder();
+		for( PathOperation op : ops ) {
+			switch( op ) {
+			case PathOperation.Field(String name) -> sb.append( "." ).append( name );
+			case PathOperation.ArrayIndex(var idx) -> sb.append( "[" ).append( idx.intValue() ).append( "]" );
+			default -> throw new IllegalArgumentException( "Unsupported path operation in pval: " + op );
+			}
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Parses a path string like "data[1].field[2].subfield" into a VariablePath.
+	 */
+	private VariablePath parsePathString( String pathStr ) {
+		VariablePathBuilder b = new VariablePathBuilder( false );
+		for( String s : pathStr.split( "\\." ) ) {
+			int i = s.indexOf( '[' );
+			if( i < 0 )
+				b.add( s );
+			else
+				b.add( s.substring( 0, i ), Integer.parseInt( s.substring( i + 1, s.length() - 1 ) ) );
+		}
+		return b.toVariablePath();
+	}
+}

--- a/jolie/src/main/java/jolie/runtime/expression/SumExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/SumExpression.java
@@ -28,7 +28,7 @@ import jolie.process.TransformationReason;
 import jolie.runtime.Value;
 
 public final class SumExpression implements Expression {
-	private final Operand[] children;
+	final Operand[] children;
 
 	public SumExpression( Operand[] children ) {
 		this.children = children;

--- a/jolie/src/main/java/jolie/runtime/expression/ValueNavigator.java
+++ b/jolie/src/main/java/jolie/runtime/expression/ValueNavigator.java
@@ -1,0 +1,127 @@
+package jolie.runtime.expression;
+
+import jolie.lang.parse.ast.expression.PathOperation;
+import jolie.runtime.Value;
+import jolie.runtime.ValueVector;
+import jolie.runtime.VariablePath;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import com.google.common.primitives.UnsignedInteger;
+
+final class ValueNavigator {
+
+	private ValueNavigator() {}
+
+	/**
+	 * Navigates value tree applying operations sequentially. Read-only: no vivification. Example:
+	 * data.items[0].name="A", ops=[Field("items"), ArrayWildcard(), Field("name")] →
+	 * [Candidate(Value("A"), "data.items[0].name"), Candidate(Value("B"), "data.items[1].name")]
+	 * Extract: VALUES→.map(Candidate::value).toList() | PATHS→.map(Candidate::path).toList()
+	 */
+	public static List< Candidate > navigate( VariablePath from, List< PathOperation > ops ) {
+		ValueVector rootVec = from.getValueVectorOrNull(); // SAFE: uses children().get(), not getChildren()
+		if( rootVec == null || rootVec.isEmpty() )
+			return List.of();
+
+		List< Candidate > candidates = new ArrayList<>();
+		candidates.add( new Candidate( rootVec, from.path()[ 0 ].key().evaluate().strValue() ) );
+
+		for( PathOperation op : ops ) {
+			List< Candidate > next = new ArrayList<>();
+			candidates.forEach( c -> next.addAll( expand( c, op ) ) );
+			candidates = next;
+		}
+
+		return candidates;
+	}
+
+	/** Navigates from a Candidate (for $ expressions in WHERE clauses) */
+	public static List< Candidate > navigateFromCandidate( Candidate start, List< PathOperation > ops ) {
+		List< Candidate > candidates = List.of( start );
+
+		for( PathOperation op : ops )
+			candidates = candidates.stream().flatMap( c -> expand( c, op ).stream() ).toList();
+
+		return candidates;
+	}
+
+	private static List< Candidate > expand( Candidate c, PathOperation op ) {
+		return switch( op ) {
+		// .field
+		case PathOperation.Field(String name) -> {
+			if( !c.value().hasChildren( name ) )
+				yield List.of(); // SAFE: checks via children.get() on AtomicRef, no map creation
+			ValueVector vec = c.value().children().get( name ); // SAFE: map exists after hasChildren check
+			yield vec.isEmpty() ? List.of() : List.of( new Candidate( vec, c.path() + "." + name ) );
+		}
+
+		// .*
+		case PathOperation.FieldWildcard() -> {
+			if( !c.value().hasChildren() )
+				yield List.of(); // SAFE: checks via children.get() on AtomicRef, no map creation
+			List< Candidate > results = new ArrayList<>();
+			c.value().children().forEach( ( name, vec ) -> { // SAFE: map exists after hasChildren check
+				if( !vec.isEmpty() )
+					results.add( new Candidate( vec, c.path() + "." + name ) );
+			} );
+			yield results;
+		}
+
+		// [n]
+		case PathOperation.ArrayIndex(UnsignedInteger idx) ->
+			idx.intValue() < c.vector().size()
+				? List.of( new Candidate( c.vector(), idx, c.path() + "[" + idx + "]" ) )
+				: List.of();
+
+		// [*]
+		case PathOperation.ArrayWildcard() -> {
+			List< Candidate > results = new ArrayList<>();
+			for( int i = 0; i < c.vector().size(); i++ ) {
+				results.add( new Candidate( c.vector(), UnsignedInteger.valueOf( i ), c.path() + "[" + i + "]" ) );
+			}
+			yield results;
+		}
+
+		// ..field
+		case PathOperation.RecursiveField(String name) -> descendRecursive( c, fn -> fn.equals( name ) );
+
+		// ..*
+		case PathOperation.RecursiveWildcard() -> descendRecursive( c, fn -> true );
+		};
+	}
+
+	/**
+	 * BFS recursive descent matching fields via predicate. Example: "a" + (name=="id") → all a..id |
+	 * "a" + (true) → all a..*
+	 */
+	private static List< Candidate > descendRecursive( Candidate start, Predicate< String > match ) {
+		List< Candidate > results = new ArrayList<>();
+		record Item(Value v, String p) {
+		}
+		List< Item > queue = new ArrayList<>();
+		queue.add( new Item( start.value(), start.path() ) );
+
+		while( !queue.isEmpty() ) {
+			Item item = queue.removeFirst();
+			if( !item.v.hasChildren() )
+				continue; // SAFE: checks via children.get() on AtomicRef, no map creation
+
+			item.v.children().forEach( ( name, vec ) -> { // SAFE: map exists after hasChildren check
+				if( vec.isEmpty() )
+					return;
+				String fieldPath = item.p + "." + name;
+
+				if( match.test( name ) )
+					results.add( new Candidate( vec, fieldPath ) );
+
+				for( int i = 0; i < vec.size(); i++ ) {
+					String elementPath = fieldPath + "[" + i + "]";
+					queue.add( new Item( vec.get( i ), elementPath ) );
+				}
+			} );
+		}
+
+		return results;
+	}
+}

--- a/jolie/src/main/java/jolie/runtime/expression/ValuesExpression.java
+++ b/jolie/src/main/java/jolie/runtime/expression/ValuesExpression.java
@@ -1,0 +1,46 @@
+package jolie.runtime.expression;
+
+import jolie.lang.parse.ast.expression.PathOperation;
+import jolie.process.TransformationReason;
+import jolie.runtime.Value;
+import jolie.runtime.VariablePath;
+import java.util.List;
+
+/**
+ * VALUES expression: returns actual values matching pattern and WHERE filter. Example: values
+ * data[*] where $ > 5 → [10, 7] (the actual values)
+ */
+public class ValuesExpression implements Expression {
+	private final VariablePath path;
+	private final List< PathOperation > ops;
+	private final Expression where;
+
+	public ValuesExpression(
+		VariablePath path,
+		List< PathOperation > ops,
+		Expression where ) {
+		this.path = path;
+		this.ops = ops;
+		this.where = where;
+	}
+
+	@Override
+	public Expression cloneExpression( TransformationReason reason ) {
+		return new ValuesExpression(
+			(VariablePath) path.cloneExpression( reason ),
+			ops,
+			where.cloneExpression( reason ) );
+	}
+
+	@Override
+	public Value evaluate() {
+		Value result = Value.create();
+		for( Candidate c : ValueNavigator.navigate( path, ops ) ) {
+			if( WhereEvaluator.matches( where, c ) ) {
+				int index = result.getChildren( "results" ).size();
+				result.getChildren( "results" ).get( index ).deepCopy( c.value() );
+			}
+		}
+		return result;
+	}
+}

--- a/jolie/src/main/java/jolie/runtime/expression/WhereEvaluator.java
+++ b/jolie/src/main/java/jolie/runtime/expression/WhereEvaluator.java
@@ -80,10 +80,12 @@ public class WhereEvaluator {
 		return switch( expr ) {
 		// $
 		case CurrentValueExpression cve -> ValueNavigator.navigateFromCandidate( cve.currentCandidate, cve.operations );
+		// Non-$ expressions: wrap value in Candidate for type uniformity (candidate is ignored by
+		// compare())
 		default -> {
 			ValueVector vec = ValueVector.create();
 			vec.add( expr.evaluate() );
-			yield List.of( new Candidate( vec, "$" ) );
+			yield List.of( new Candidate( vec, "42" ) );
 		}
 		};
 	}

--- a/jolie/src/main/java/jolie/runtime/expression/WhereEvaluator.java
+++ b/jolie/src/main/java/jolie/runtime/expression/WhereEvaluator.java
@@ -13,10 +13,12 @@ public class WhereEvaluator {
 		return eval( where );
 	}
 
-	private static void bind( Expression expr, Candidate candidate ) {
+	static void bind( Expression expr, Candidate candidate ) {
 		switch( expr ) {
 		// $
 		case CurrentValueExpression cve -> cve.setCurrentCandidate( candidate );
+		// #
+		case ValueVectorSizeExpression vvse -> vvse.bind( candidate );
 		// ==, !=, <, >, <=, >=
 		case CompareCondition cmp -> {
 			bind( cmp.leftExpression, candidate );
@@ -34,6 +36,15 @@ public class WhereEvaluator {
 		}
 		// !
 		case NotExpression not -> bind( not.expression, candidate );
+		// Arithmetic: +, -, *, /, %
+		case SumExpression sum -> {
+			for( var operand : sum.children )
+				bind( operand.expression(), candidate );
+		}
+		case ProductExpression prod -> {
+			for( var operand : prod.children )
+				bind( operand.expression(), candidate );
+		}
 		default -> {
 		}
 		}

--- a/jolie/src/main/java/jolie/runtime/expression/WhereEvaluator.java
+++ b/jolie/src/main/java/jolie/runtime/expression/WhereEvaluator.java
@@ -32,6 +32,8 @@ public class WhereEvaluator {
 			for( var c : or.children )
 				bind( c, candidate );
 		}
+		// !
+		case NotExpression not -> bind( not.expression, candidate );
 		default -> {
 		}
 		}
@@ -68,6 +70,8 @@ public class WhereEvaluator {
 					yield true;
 			yield false;
 		}
+		// !
+		case NotExpression not -> !eval( not.expression );
 		default -> expr.evaluate().boolValue();
 		};
 	}

--- a/jolie/src/main/java/jolie/runtime/typing/BasicType.java
+++ b/jolie/src/main/java/jolie/runtime/typing/BasicType.java
@@ -42,6 +42,7 @@ public class BasicType< T > {
 	private static final Predicate< Value > BOOL_PREDICATE = Value::isBool;
 	private static final Predicate< Value > VOID_PREDICATE = v -> v.valueObject() == null;
 	private static final Predicate< Value > RAW_PREDICATE = Value::isByteArray;
+	private static final Predicate< Value > PATH_PREDICATE = Value::isPath;
 
 	static {
 		PURE_BASIC_TYPES.put( NativeType.ANY,
@@ -62,6 +63,8 @@ public class BasicType< T > {
 			new BasicType<>( NativeType.VOID, VOID_PREDICATE, Collections.emptyList(), v -> {
 				throw new IllegalStateException( "void values cannot be refined" );
 			} ) );
+		PURE_BASIC_TYPES.put( NativeType.PATH,
+			new BasicType<>( NativeType.PATH, PATH_PREDICATE, Collections.emptyList(), Value::pathValue ) );
 	}
 
 	private final NativeType nativeType;

--- a/launchers/unix/jolie
+++ b/launchers/unix/jolie
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-java -ea:jolie... -ea:joliex... -Djava.rmi.server.codebase=file:/$JOLIE_HOME/extensions/rmi.jar -cp $JOLIE_HOME/lib/libjolie.jar:$JOLIE_HOME/lib/automaton.jar:$JOLIE_HOME/lib/commons-text.jar:$JOLIE_HOME/lib/jolie-js.jar:$JOLIE_HOME/lib/json-simple.jar:$JOLIE_HOME/jolie.jar:$JOLIE_HOME/jolie-cli.jar jolie.Jolie -l ./lib/*:$JOLIE_HOME/lib:$JOLIE_HOME/javaServices/*:$JOLIE_HOME/extensions/* -i $JOLIE_HOME/include -p $JOLIE_HOME/packages "$@"
+java -ea:jolie... -ea:joliex... -Djava.rmi.server.codebase=file:/$JOLIE_HOME/extensions/rmi.jar -cp $JOLIE_HOME/lib/libjolie.jar:$JOLIE_HOME/lib/automaton.jar:$JOLIE_HOME/lib/commons-text.jar:$JOLIE_HOME/lib/jolie-js.jar:$JOLIE_HOME/lib/json-simple.jar:$JOLIE_HOME/lib/guava.jar:$JOLIE_HOME/jolie.jar:$JOLIE_HOME/jolie-cli.jar jolie.Jolie -l ./lib/*:$JOLIE_HOME/lib:$JOLIE_HOME/javaServices/*:$JOLIE_HOME/extensions/* -i $JOLIE_HOME/include -p $JOLIE_HOME/packages "$@"

--- a/libjolie/pom.xml
+++ b/libjolie/pom.xml
@@ -79,5 +79,10 @@
 			<scope>test</scope>
 			<version>5.9.2</version>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>RELEASE</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/libjolie/src/main/java/jolie/lang/Keywords.java
+++ b/libjolie/src/main/java/jolie/lang/Keywords.java
@@ -82,6 +82,8 @@ public class Keywords {
 	public static final String CH = "cH";
 	public static final String COMP = "comp";
 	public static final String NULL_PROCESS = "nullProcess";
+	public static final String PATHS = "paths";
+	public static final String VALUES = "values";
 
 	// Languages that can be embedded
 	public static final String JOLIE = "Jolie";
@@ -119,7 +121,8 @@ public class Keywords {
 
 	private static final List< String > MAIN_KEYWORDS =
 		List.of( "for", "while", "if", "else", "else if", "foreach", "with", "undef",
-			"synchronized", "scope", "install", "spawn", "over", "in", "throw", "cH", "comp", "nullProcess" );
+			"synchronized", "scope", "install", "spawn", "over", "in", "throw", "cH", "comp", "nullProcess",
+			"paths", "values" );
 
 	private static final List< String > INTERFACE_KEYWORDS = List.of( "oneWay", "requestResponse" );
 

--- a/libjolie/src/main/java/jolie/lang/NativeType.java
+++ b/libjolie/src/main/java/jolie/lang/NativeType.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public enum NativeType {
 	// UNDEFINED( "undefined" ),
 	STRING( "string" ), INT( "int" ), LONG( "long" ), BOOL( "bool" ), DOUBLE( "double" ), VOID( "void" ), RAW(
-		"raw" ), ANY( "any" );
+		"raw" ), ANY( "any" ), PATH( "path" );
 
 	private final static Map< String, NativeType > ID_MAP;
 

--- a/libjolie/src/main/java/jolie/lang/parse/OLParseTreeOptimizer.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParseTreeOptimizer.java
@@ -786,7 +786,7 @@ public class OLParseTreeOptimizer {
 		public void visit( ValueVectorSizeExpressionNode n ) {
 			currNode = new ValueVectorSizeExpressionNode(
 				n.context(),
-				optimizePath( n.variablePath() ) );
+				optimize( n.expression() ) );
 		}
 
 		@Override

--- a/libjolie/src/main/java/jolie/lang/parse/OLParseTreeOptimizer.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParseTreeOptimizer.java
@@ -64,6 +64,7 @@ import jolie.lang.parse.ast.OneWayOperationStatement;
 import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
+import jolie.lang.parse.ast.PvalAssignStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -678,6 +679,15 @@ public class OLParseTreeOptimizer {
 				n.context(),
 				optimize( n.pathExpression() ),
 				n.pathOperations() );
+		}
+
+		@Override
+		public void visit( PvalAssignStatement n ) {
+			currNode = new PvalAssignStatement(
+				n.context(),
+				optimize( n.pathExpression() ),
+				n.pathOperations(),
+				optimize( n.expression() ) );
 		}
 
 		@Override

--- a/libjolie/src/main/java/jolie/lang/parse/OLParseTreeOptimizer.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParseTreeOptimizer.java
@@ -65,6 +65,7 @@ import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
 import jolie.lang.parse.ast.PvalAssignStatement;
+import jolie.lang.parse.ast.PvalDeepCopyStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -688,6 +689,15 @@ public class OLParseTreeOptimizer {
 				optimize( n.pathExpression() ),
 				n.pathOperations(),
 				optimize( n.expression() ) );
+		}
+
+		@Override
+		public void visit( PvalDeepCopyStatement n ) {
+			currNode = new PvalDeepCopyStatement(
+				n.context(),
+				optimize( n.pathExpression() ),
+				n.pathOperations(),
+				optimize( n.rightExpression() ) );
 		}
 
 		@Override

--- a/libjolie/src/main/java/jolie/lang/parse/OLParseTreeOptimizer.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParseTreeOptimizer.java
@@ -96,6 +96,7 @@ import jolie.lang.parse.ast.expression.ConstantDoubleExpression;
 import jolie.lang.parse.ast.expression.ConstantIntegerExpression;
 import jolie.lang.parse.ast.expression.ConstantLongExpression;
 import jolie.lang.parse.ast.expression.ConstantStringExpression;
+import jolie.lang.parse.ast.expression.CurrentValueNode;
 import jolie.lang.parse.ast.expression.FreshValueExpressionNode;
 import jolie.lang.parse.ast.expression.IfExpressionNode;
 import jolie.lang.parse.ast.expression.InlineTreeExpressionNode;
@@ -103,9 +104,11 @@ import jolie.lang.parse.ast.expression.InstanceOfExpressionNode;
 import jolie.lang.parse.ast.expression.IsTypeExpressionNode;
 import jolie.lang.parse.ast.expression.NotExpressionNode;
 import jolie.lang.parse.ast.expression.OrConditionNode;
+import jolie.lang.parse.ast.expression.PathsExpressionNode;
 import jolie.lang.parse.ast.expression.ProductExpressionNode;
 import jolie.lang.parse.ast.expression.SolicitResponseExpressionNode;
 import jolie.lang.parse.ast.expression.SumExpressionNode;
+import jolie.lang.parse.ast.expression.ValuesExpressionNode;
 import jolie.lang.parse.ast.expression.VariableExpressionNode;
 import jolie.lang.parse.ast.expression.VoidExpressionNode;
 import jolie.lang.parse.ast.types.TypeChoiceDefinition;
@@ -645,6 +648,27 @@ public class OLParseTreeOptimizer {
 		@Override
 		public void visit( ConstantStringExpression n ) {
 			currNode = new ConstantStringExpression( n.context(), n.value().intern() );
+		}
+
+		@Override
+		public void visit( CurrentValueNode n ) {
+			currNode = n;
+		}
+
+		@Override
+		public void visit( PathsExpressionNode n ) {
+			currNode = new PathsExpressionNode(
+				n.context(),
+				n.operations(),
+				optimize( n.whereClause() ) );
+		}
+
+		@Override
+		public void visit( ValuesExpressionNode n ) {
+			currNode = new ValuesExpressionNode(
+				n.context(),
+				n.operations(),
+				optimize( n.whereClause() ) );
 		}
 
 		@Override

--- a/libjolie/src/main/java/jolie/lang/parse/OLParseTreeOptimizer.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParseTreeOptimizer.java
@@ -106,6 +106,7 @@ import jolie.lang.parse.ast.expression.NotExpressionNode;
 import jolie.lang.parse.ast.expression.OrConditionNode;
 import jolie.lang.parse.ast.expression.PathsExpressionNode;
 import jolie.lang.parse.ast.expression.ProductExpressionNode;
+import jolie.lang.parse.ast.expression.PvalExpressionNode;
 import jolie.lang.parse.ast.expression.SolicitResponseExpressionNode;
 import jolie.lang.parse.ast.expression.SumExpressionNode;
 import jolie.lang.parse.ast.expression.ValuesExpressionNode;
@@ -669,6 +670,14 @@ public class OLParseTreeOptimizer {
 				n.context(),
 				n.operations(),
 				optimize( n.whereClause() ) );
+		}
+
+		@Override
+		public void visit( PvalExpressionNode n ) {
+			currNode = new PvalExpressionNode(
+				n.context(),
+				optimize( n.pathExpression() ),
+				n.pathOperations() );
 		}
 
 		@Override

--- a/libjolie/src/main/java/jolie/lang/parse/OLParser.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParser.java
@@ -94,6 +94,7 @@ import jolie.lang.parse.ast.OperationCollector;
 import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
+import jolie.lang.parse.ast.PvalAssignStatement;
 import jolie.lang.parse.ast.PortInfo;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
@@ -2504,6 +2505,9 @@ public class OLParser extends AbstractParser {
 			nextToken();
 			retVal = new PreDecrementStatement( getContext(), parseVariablePath() );
 			break;
+		case PVAL:
+			retVal = parsePvalAssignStatement();
+			break;
 		case UNDEF:
 			nextToken();
 			eat(
@@ -2942,6 +2946,20 @@ public class OLParser extends AbstractParser {
 		}
 
 		return retVal;
+	}
+
+	private OLSyntaxNode parsePvalAssignStatement()
+		throws IOException, ParserException {
+		ParsingContext ctx = getContext();
+		nextToken(); // consume PVAL
+		eat( Scanner.TokenType.LPAREN, "expected (" );
+		OLSyntaxNode pathExpr = parseBasicExpression();
+		eat( Scanner.TokenType.RPAREN, "expected )" );
+		List< PathOperation > pathOps = new ArrayList<>();
+		parsePathOperationsSuffix( pathOps );
+		eat( Scanner.TokenType.ASSIGN, "expected = after pval" );
+		OLSyntaxNode expr = parseExpression();
+		return new PvalAssignStatement( ctx, pathExpr, pathOps, expr );
 	}
 
 	private VariablePathNode parseVariablePath()

--- a/libjolie/src/main/java/jolie/lang/parse/OLParser.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParser.java
@@ -2958,18 +2958,20 @@ public class OLParser extends AbstractParser {
 		eat( Scanner.TokenType.RPAREN, "expected )" );
 		List< PathOperation > pathOps = new ArrayList<>();
 		parsePathOperationsSuffix( pathOps );
-		if( token.is( Scanner.TokenType.ASSIGN ) ) {
+		return switch( token.type() ) {
+		case ASSIGN -> {
 			nextToken();
-			OLSyntaxNode expr = parseExpression();
-			return new PvalAssignStatement( ctx, pathExpr, pathOps, expr );
-		} else if( token.is( Scanner.TokenType.DEEP_COPY_LEFT ) ) {
-			nextToken();
-			OLSyntaxNode expr = parseExpression();
-			return new PvalDeepCopyStatement( ctx, pathExpr, pathOps, expr );
-		} else {
-			throwException( "expected = or << after pval" );
-			return null;
+			yield new PvalAssignStatement( ctx, pathExpr, pathOps, parseExpression() );
 		}
+		case DEEP_COPY_LEFT -> {
+			nextToken();
+			yield new PvalDeepCopyStatement( ctx, pathExpr, pathOps, parseExpression() );
+		}
+		default -> {
+			throwException( "expected = or << after pval" );
+			yield null;
+		}
+		};
 	}
 
 	private VariablePathNode parseVariablePath()

--- a/libjolie/src/main/java/jolie/lang/parse/OLParser.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParser.java
@@ -95,6 +95,7 @@ import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
 import jolie.lang.parse.ast.PvalAssignStatement;
+import jolie.lang.parse.ast.PvalDeepCopyStatement;
 import jolie.lang.parse.ast.PortInfo;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
@@ -2957,9 +2958,18 @@ public class OLParser extends AbstractParser {
 		eat( Scanner.TokenType.RPAREN, "expected )" );
 		List< PathOperation > pathOps = new ArrayList<>();
 		parsePathOperationsSuffix( pathOps );
-		eat( Scanner.TokenType.ASSIGN, "expected = after pval" );
-		OLSyntaxNode expr = parseExpression();
-		return new PvalAssignStatement( ctx, pathExpr, pathOps, expr );
+		if( token.is( Scanner.TokenType.ASSIGN ) ) {
+			nextToken();
+			OLSyntaxNode expr = parseExpression();
+			return new PvalAssignStatement( ctx, pathExpr, pathOps, expr );
+		} else if( token.is( Scanner.TokenType.DEEP_COPY_LEFT ) ) {
+			nextToken();
+			OLSyntaxNode expr = parseExpression();
+			return new PvalDeepCopyStatement( ctx, pathExpr, pathOps, expr );
+		} else {
+			throwException( "expected = or << after pval" );
+			return null;
+		}
 	}
 
 	private VariablePathNode parseVariablePath()

--- a/libjolie/src/main/java/jolie/lang/parse/OLParser.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLParser.java
@@ -131,6 +131,7 @@ import jolie.lang.parse.ast.expression.CurrentValueNode;
 import jolie.lang.parse.ast.expression.FreshValueExpressionNode;
 import jolie.lang.parse.ast.expression.PathOperation;
 import jolie.lang.parse.ast.expression.PathsExpressionNode;
+import jolie.lang.parse.ast.expression.PvalExpressionNode;
 import jolie.lang.parse.ast.expression.ValuesExpressionNode;
 import jolie.lang.parse.ast.expression.IfExpressionNode;
 import jolie.lang.parse.ast.expression.InlineTreeExpressionNode;
@@ -3586,6 +3587,15 @@ public class OLParser extends AbstractParser {
 			case VALUES:
 				nextToken();
 				retVal = new ValuesExpressionNode( getContext(), parsePathOperations(), parseWhereClause() );
+				break;
+			case PVAL:
+				nextToken();
+				eat( Scanner.TokenType.LPAREN, "expected (" );
+				OLSyntaxNode pvalPathExpr = parseBasicExpression();
+				eat( Scanner.TokenType.RPAREN, "expected )" );
+				List< PathOperation > pvalOps = new ArrayList<>();
+				parsePathOperationsSuffix( pvalOps );
+				retVal = new PvalExpressionNode( getContext(), pvalPathExpr, pvalOps );
 				break;
 			case INCREMENT:
 				nextToken();

--- a/libjolie/src/main/java/jolie/lang/parse/OLVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLVisitor.java
@@ -160,6 +160,12 @@ public interface OLVisitor< C, R > {
 
 	R visit( ConstantStringExpression n, C ctx );
 
+	R visit( CurrentValueNode n, C ctx );
+
+	R visit( PathsExpressionNode n, C ctx );
+
+	R visit( ValuesExpressionNode n, C ctx );
+
 	R visit( ProductExpressionNode n, C ctx );
 
 	R visit( SumExpressionNode n, C ctx );

--- a/libjolie/src/main/java/jolie/lang/parse/OLVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLVisitor.java
@@ -166,6 +166,8 @@ public interface OLVisitor< C, R > {
 
 	R visit( ValuesExpressionNode n, C ctx );
 
+	R visit( PvalExpressionNode n, C ctx );
+
 	R visit( ProductExpressionNode n, C ctx );
 
 	R visit( SumExpressionNode n, C ctx );

--- a/libjolie/src/main/java/jolie/lang/parse/OLVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLVisitor.java
@@ -57,6 +57,7 @@ import jolie.lang.parse.ast.OneWayOperationStatement;
 import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
+import jolie.lang.parse.ast.PvalAssignStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -167,6 +168,8 @@ public interface OLVisitor< C, R > {
 	R visit( ValuesExpressionNode n, C ctx );
 
 	R visit( PvalExpressionNode n, C ctx );
+
+	R visit( PvalAssignStatement n, C ctx );
 
 	R visit( ProductExpressionNode n, C ctx );
 

--- a/libjolie/src/main/java/jolie/lang/parse/OLVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/OLVisitor.java
@@ -58,6 +58,7 @@ import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
 import jolie.lang.parse.ast.PvalAssignStatement;
+import jolie.lang.parse.ast.PvalDeepCopyStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -170,6 +171,8 @@ public interface OLVisitor< C, R > {
 	R visit( PvalExpressionNode n, C ctx );
 
 	R visit( PvalAssignStatement n, C ctx );
+
+	R visit( PvalDeepCopyStatement n, C ctx );
 
 	R visit( ProductExpressionNode n, C ctx );
 

--- a/libjolie/src/main/java/jolie/lang/parse/Scanner.java
+++ b/libjolie/src/main/java/jolie/lang/parse/Scanner.java
@@ -79,6 +79,7 @@ public class Scanner implements AutoCloseable {
 		LINKIN,				///< linkIn
 		LINKOUT,			///< linkOut
 		INSTANCE_OF,		///< instanceof
+		HAS,				///< has
 		EQUAL,				///< ==
 		AND,				///< &&
 		OR,					///< ||
@@ -145,6 +146,8 @@ public class Scanner implements AutoCloseable {
 		FROM,				///< from
 		PRIVATE,			///< private
 		PUBLIC,				///< public
+		PATHS,				///< paths
+		VALUES,				///< values
 		NEWLINE,			///< a newline token
 		ERROR				///< Scanner error
 	}
@@ -190,12 +193,15 @@ public class Scanner implements AutoCloseable {
 		UNRESERVED_KEYWORDS.put( "is_long", TokenType.IS_LONG );
 		UNRESERVED_KEYWORDS.put( "is_double", TokenType.IS_DOUBLE );
 		UNRESERVED_KEYWORDS.put( "instanceof", TokenType.INSTANCE_OF );
+		UNRESERVED_KEYWORDS.put( "has", TokenType.HAS );
 		UNRESERVED_KEYWORDS.put( NativeType.INT.id(), TokenType.CAST_INT );
 		UNRESERVED_KEYWORDS.put( NativeType.STRING.id(), TokenType.CAST_STRING );
 		UNRESERVED_KEYWORDS.put( NativeType.BOOL.id(), TokenType.CAST_BOOL );
 		UNRESERVED_KEYWORDS.put( NativeType.DOUBLE.id(), TokenType.CAST_DOUBLE );
 		UNRESERVED_KEYWORDS.put( NativeType.LONG.id(), TokenType.CAST_LONG );
 		UNRESERVED_KEYWORDS.put( "throws", TokenType.THROWS );
+		UNRESERVED_KEYWORDS.put( "paths", TokenType.PATHS );
+		UNRESERVED_KEYWORDS.put( "values", TokenType.VALUES );
 		UNRESERVED_KEYWORDS.put( "cH", TokenType.CURRENT_HANDLER );
 		UNRESERVED_KEYWORDS.put( "init", TokenType.INIT );
 		UNRESERVED_KEYWORDS.put( "with", TokenType.WITH );
@@ -968,6 +974,8 @@ public class Scanner implements AutoCloseable {
 							retval = new Token( TokenType.CARET );
 						} else if ( ch == '?' ) {
 							retval = new Token( TokenType.QUESTION_MARK );
+						} else if ( ch == '$' ) {
+							retval = new Token( TokenType.DOLLAR );
 						} else if ( isNewLineChar( ch ) ) {
 							retval = new Token( TokenType.NEWLINE );
 						}

--- a/libjolie/src/main/java/jolie/lang/parse/Scanner.java
+++ b/libjolie/src/main/java/jolie/lang/parse/Scanner.java
@@ -148,6 +148,7 @@ public class Scanner implements AutoCloseable {
 		PUBLIC,				///< public
 		PATHS,				///< paths
 		VALUES,				///< values
+		WHERE,				///< where
 		NEWLINE,			///< a newline token
 		ERROR				///< Scanner error
 	}
@@ -202,6 +203,7 @@ public class Scanner implements AutoCloseable {
 		UNRESERVED_KEYWORDS.put( "throws", TokenType.THROWS );
 		UNRESERVED_KEYWORDS.put( "paths", TokenType.PATHS );
 		UNRESERVED_KEYWORDS.put( "values", TokenType.VALUES );
+		UNRESERVED_KEYWORDS.put( "where", TokenType.WHERE );
 		UNRESERVED_KEYWORDS.put( "cH", TokenType.CURRENT_HANDLER );
 		UNRESERVED_KEYWORDS.put( "init", TokenType.INIT );
 		UNRESERVED_KEYWORDS.put( "with", TokenType.WITH );

--- a/libjolie/src/main/java/jolie/lang/parse/Scanner.java
+++ b/libjolie/src/main/java/jolie/lang/parse/Scanner.java
@@ -149,6 +149,7 @@ public class Scanner implements AutoCloseable {
 		PATHS,				///< paths
 		VALUES,				///< values
 		WHERE,				///< where
+		PVAL,				///< pval
 		NEWLINE,			///< a newline token
 		ERROR				///< Scanner error
 	}
@@ -204,6 +205,7 @@ public class Scanner implements AutoCloseable {
 		UNRESERVED_KEYWORDS.put( "paths", TokenType.PATHS );
 		UNRESERVED_KEYWORDS.put( "values", TokenType.VALUES );
 		UNRESERVED_KEYWORDS.put( "where", TokenType.WHERE );
+		UNRESERVED_KEYWORDS.put( "pval", TokenType.PVAL );
 		UNRESERVED_KEYWORDS.put( "cH", TokenType.CURRENT_HANDLER );
 		UNRESERVED_KEYWORDS.put( "init", TokenType.INIT );
 		UNRESERVED_KEYWORDS.put( "with", TokenType.WITH );

--- a/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
+++ b/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
@@ -113,6 +113,7 @@ import jolie.lang.parse.ast.expression.ConstantDoubleExpression;
 import jolie.lang.parse.ast.expression.ConstantIntegerExpression;
 import jolie.lang.parse.ast.expression.ConstantLongExpression;
 import jolie.lang.parse.ast.expression.ConstantStringExpression;
+import jolie.lang.parse.ast.expression.CurrentValueNode;
 import jolie.lang.parse.ast.expression.FreshValueExpressionNode;
 import jolie.lang.parse.ast.expression.IfExpressionNode;
 import jolie.lang.parse.ast.expression.InlineTreeExpressionNode;
@@ -120,9 +121,11 @@ import jolie.lang.parse.ast.expression.InstanceOfExpressionNode;
 import jolie.lang.parse.ast.expression.IsTypeExpressionNode;
 import jolie.lang.parse.ast.expression.NotExpressionNode;
 import jolie.lang.parse.ast.expression.OrConditionNode;
+import jolie.lang.parse.ast.expression.PathsExpressionNode;
 import jolie.lang.parse.ast.expression.ProductExpressionNode;
 import jolie.lang.parse.ast.expression.SolicitResponseExpressionNode;
 import jolie.lang.parse.ast.expression.SumExpressionNode;
+import jolie.lang.parse.ast.expression.ValuesExpressionNode;
 import jolie.lang.parse.ast.expression.VariableExpressionNode;
 import jolie.lang.parse.ast.expression.VoidExpressionNode;
 import jolie.lang.parse.ast.types.TypeChoiceDefinition;
@@ -1048,6 +1051,19 @@ public class SemanticVerifier implements UnitOLVisitor {
 
 	@Override
 	public void visit( ConstantStringExpression n ) {}
+
+	@Override
+	public void visit( CurrentValueNode n ) {}
+
+	@Override
+	public void visit( PathsExpressionNode n ) {
+		n.whereClause().accept( this );
+	}
+
+	@Override
+	public void visit( ValuesExpressionNode n ) {
+		n.whereClause().accept( this );
+	}
 
 	@Override
 	public void visit( ConstantLongExpression n ) {}

--- a/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
+++ b/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
@@ -81,6 +81,7 @@ import jolie.lang.parse.ast.OperationDeclaration;
 import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
+import jolie.lang.parse.ast.PvalAssignStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -1070,6 +1071,9 @@ public class SemanticVerifier implements UnitOLVisitor {
 	public void visit( PvalExpressionNode n ) {
 		n.pathExpression().accept( this );
 	}
+
+	@Override
+	public void visit( PvalAssignStatement n ) {}
 
 	@Override
 	public void visit( ConstantLongExpression n ) {}

--- a/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
+++ b/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
@@ -1175,7 +1175,7 @@ public class SemanticVerifier implements UnitOLVisitor {
 
 	@Override
 	public void visit( ValueVectorSizeExpressionNode n ) {
-		n.variablePath().accept( this );
+		n.expression().accept( this );
 	}
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
+++ b/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
@@ -82,6 +82,7 @@ import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
 import jolie.lang.parse.ast.PvalAssignStatement;
+import jolie.lang.parse.ast.PvalDeepCopyStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -1074,6 +1075,9 @@ public class SemanticVerifier implements UnitOLVisitor {
 
 	@Override
 	public void visit( PvalAssignStatement n ) {}
+
+	@Override
+	public void visit( PvalDeepCopyStatement n ) {}
 
 	@Override
 	public void visit( ConstantLongExpression n ) {}

--- a/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
+++ b/libjolie/src/main/java/jolie/lang/parse/SemanticVerifier.java
@@ -123,6 +123,7 @@ import jolie.lang.parse.ast.expression.NotExpressionNode;
 import jolie.lang.parse.ast.expression.OrConditionNode;
 import jolie.lang.parse.ast.expression.PathsExpressionNode;
 import jolie.lang.parse.ast.expression.ProductExpressionNode;
+import jolie.lang.parse.ast.expression.PvalExpressionNode;
 import jolie.lang.parse.ast.expression.SolicitResponseExpressionNode;
 import jolie.lang.parse.ast.expression.SumExpressionNode;
 import jolie.lang.parse.ast.expression.ValuesExpressionNode;
@@ -1063,6 +1064,11 @@ public class SemanticVerifier implements UnitOLVisitor {
 	@Override
 	public void visit( ValuesExpressionNode n ) {
 		n.whereClause().accept( this );
+	}
+
+	@Override
+	public void visit( PvalExpressionNode n ) {
+		n.pathExpression().accept( this );
 	}
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/TypeChecker.java
+++ b/libjolie/src/main/java/jolie/lang/parse/TypeChecker.java
@@ -70,6 +70,7 @@ import jolie.lang.parse.ast.OneWayOperationStatement;
 import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
+import jolie.lang.parse.ast.PvalAssignStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -794,6 +795,9 @@ public class TypeChecker implements UnitOLVisitor {
 
 	@Override
 	public void visit( PvalExpressionNode n ) {}
+
+	@Override
+	public void visit( PvalAssignStatement n ) {}
 
 	@Override
 	public void visit( ProductExpressionNode n ) {}

--- a/libjolie/src/main/java/jolie/lang/parse/TypeChecker.java
+++ b/libjolie/src/main/java/jolie/lang/parse/TypeChecker.java
@@ -793,6 +793,9 @@ public class TypeChecker implements UnitOLVisitor {
 	public void visit( ValuesExpressionNode n ) {}
 
 	@Override
+	public void visit( PvalExpressionNode n ) {}
+
+	@Override
 	public void visit( ProductExpressionNode n ) {}
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/TypeChecker.java
+++ b/libjolie/src/main/java/jolie/lang/parse/TypeChecker.java
@@ -71,6 +71,7 @@ import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
 import jolie.lang.parse.ast.PvalAssignStatement;
+import jolie.lang.parse.ast.PvalDeepCopyStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -798,6 +799,9 @@ public class TypeChecker implements UnitOLVisitor {
 
 	@Override
 	public void visit( PvalAssignStatement n ) {}
+
+	@Override
+	public void visit( PvalDeepCopyStatement n ) {}
 
 	@Override
 	public void visit( ProductExpressionNode n ) {}

--- a/libjolie/src/main/java/jolie/lang/parse/TypeChecker.java
+++ b/libjolie/src/main/java/jolie/lang/parse/TypeChecker.java
@@ -784,6 +784,15 @@ public class TypeChecker implements UnitOLVisitor {
 	public void visit( ConstantStringExpression n ) {}
 
 	@Override
+	public void visit( CurrentValueNode n ) {}
+
+	@Override
+	public void visit( PathsExpressionNode n ) {}
+
+	@Override
+	public void visit( ValuesExpressionNode n ) {}
+
+	@Override
 	public void visit( ProductExpressionNode n ) {}
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/UnitOLVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/UnitOLVisitor.java
@@ -59,6 +59,7 @@ import jolie.lang.parse.ast.OneWayOperationStatement;
 import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
+import jolie.lang.parse.ast.PvalAssignStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -362,6 +363,14 @@ public interface UnitOLVisitor extends OLVisitor< Unit, Unit > {
 
 	@Override
 	default Unit visit( PvalExpressionNode n, Unit ctx ) {
+		visit( n );
+		return Unit.INSTANCE;
+	}
+
+	void visit( PvalAssignStatement n );
+
+	@Override
+	default Unit visit( PvalAssignStatement n, Unit ctx ) {
 		visit( n );
 		return Unit.INSTANCE;
 	}

--- a/libjolie/src/main/java/jolie/lang/parse/UnitOLVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/UnitOLVisitor.java
@@ -358,6 +358,14 @@ public interface UnitOLVisitor extends OLVisitor< Unit, Unit > {
 		return Unit.INSTANCE;
 	}
 
+	void visit( PvalExpressionNode n );
+
+	@Override
+	default Unit visit( PvalExpressionNode n, Unit ctx ) {
+		visit( n );
+		return Unit.INSTANCE;
+	}
+
 	void visit( ProductExpressionNode n );
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/UnitOLVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/UnitOLVisitor.java
@@ -60,6 +60,7 @@ import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
 import jolie.lang.parse.ast.PvalAssignStatement;
+import jolie.lang.parse.ast.PvalDeepCopyStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -371,6 +372,14 @@ public interface UnitOLVisitor extends OLVisitor< Unit, Unit > {
 
 	@Override
 	default Unit visit( PvalAssignStatement n, Unit ctx ) {
+		visit( n );
+		return Unit.INSTANCE;
+	}
+
+	void visit( PvalDeepCopyStatement n );
+
+	@Override
+	default Unit visit( PvalDeepCopyStatement n, Unit ctx ) {
 		visit( n );
 		return Unit.INSTANCE;
 	}

--- a/libjolie/src/main/java/jolie/lang/parse/UnitOLVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/UnitOLVisitor.java
@@ -334,6 +334,30 @@ public interface UnitOLVisitor extends OLVisitor< Unit, Unit > {
 		return Unit.INSTANCE;
 	}
 
+	void visit( CurrentValueNode n );
+
+	@Override
+	default Unit visit( CurrentValueNode n, Unit ctx ) {
+		visit( n );
+		return Unit.INSTANCE;
+	}
+
+	void visit( PathsExpressionNode n );
+
+	@Override
+	default Unit visit( PathsExpressionNode n, Unit ctx ) {
+		visit( n );
+		return Unit.INSTANCE;
+	}
+
+	void visit( ValuesExpressionNode n );
+
+	@Override
+	default Unit visit( ValuesExpressionNode n, Unit ctx ) {
+		visit( n );
+		return Unit.INSTANCE;
+	}
+
 	void visit( ProductExpressionNode n );
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/ast/PvalAssignStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/PvalAssignStatement.java
@@ -1,0 +1,38 @@
+package jolie.lang.parse.ast;
+
+import java.util.List;
+
+import jolie.lang.parse.OLVisitor;
+import jolie.lang.parse.ast.expression.PathOperation;
+import jolie.lang.parse.context.ParsingContext;
+
+public class PvalAssignStatement extends OLSyntaxNode {
+	private final OLSyntaxNode pathExpression;
+	private final List< PathOperation > pathOps;
+	private final OLSyntaxNode expression;
+
+	public PvalAssignStatement( ParsingContext context, OLSyntaxNode pathExpression,
+		List< PathOperation > pathOps, OLSyntaxNode expression ) {
+		super( context );
+		this.pathExpression = pathExpression;
+		this.pathOps = pathOps;
+		this.expression = expression;
+	}
+
+	public OLSyntaxNode pathExpression() {
+		return pathExpression;
+	}
+
+	public List< PathOperation > pathOperations() {
+		return pathOps;
+	}
+
+	public OLSyntaxNode expression() {
+		return expression;
+	}
+
+	@Override
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
+	}
+}

--- a/libjolie/src/main/java/jolie/lang/parse/ast/PvalDeepCopyStatement.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/PvalDeepCopyStatement.java
@@ -1,0 +1,37 @@
+package jolie.lang.parse.ast;
+
+import java.util.List;
+import jolie.lang.parse.OLVisitor;
+import jolie.lang.parse.ast.expression.PathOperation;
+import jolie.lang.parse.context.ParsingContext;
+
+public class PvalDeepCopyStatement extends OLSyntaxNode {
+	private final OLSyntaxNode pathExpression;
+	private final List< PathOperation > pathOps;
+	private final OLSyntaxNode rightExpression;
+
+	public PvalDeepCopyStatement( ParsingContext context, OLSyntaxNode pathExpression,
+		List< PathOperation > pathOps, OLSyntaxNode rightExpression ) {
+		super( context );
+		this.pathExpression = pathExpression;
+		this.pathOps = pathOps;
+		this.rightExpression = rightExpression;
+	}
+
+	public OLSyntaxNode pathExpression() {
+		return pathExpression;
+	}
+
+	public List< PathOperation > pathOperations() {
+		return pathOps;
+	}
+
+	public OLSyntaxNode rightExpression() {
+		return rightExpression;
+	}
+
+	@Override
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
+	}
+}

--- a/libjolie/src/main/java/jolie/lang/parse/ast/ValueVectorSizeExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/ValueVectorSizeExpressionNode.java
@@ -26,15 +26,15 @@ import jolie.lang.parse.context.ParsingContext;
 
 
 public class ValueVectorSizeExpressionNode extends OLSyntaxNode {
-	private final VariablePathNode variablePath;
+	private final OLSyntaxNode expression;
 
-	public ValueVectorSizeExpressionNode( ParsingContext context, VariablePathNode variablePath ) {
+	public ValueVectorSizeExpressionNode( ParsingContext context, OLSyntaxNode expression ) {
 		super( context );
-		this.variablePath = variablePath;
+		this.expression = expression;
 	}
 
-	public VariablePathNode variablePath() {
-		return variablePath;
+	public OLSyntaxNode expression() {
+		return expression;
 	}
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/CurrentValueNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/CurrentValueNode.java
@@ -1,0 +1,29 @@
+package jolie.lang.parse.ast.expression;
+
+import jolie.lang.parse.OLVisitor;
+import jolie.lang.parse.ast.OLSyntaxNode;
+import jolie.lang.parse.context.ParsingContext;
+import java.util.List;
+
+/**
+ * Represents the current value ($) in PATHS/VALUES WHERE expressions with optional path navigation.
+ * Examples: - $ > 5 (just the current value) - $.field > 10 (navigate to field) - $.*[*] > 0
+ * (navigate with wildcards)
+ */
+public class CurrentValueNode extends OLSyntaxNode {
+	private final List< PathOperation > operations;
+
+	public CurrentValueNode( ParsingContext context, List< PathOperation > operations ) {
+		super( context );
+		this.operations = operations;
+	}
+
+	public List< PathOperation > operations() {
+		return operations;
+	}
+
+	@Override
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
+	}
+}

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/PathOperation.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/PathOperation.java
@@ -1,0 +1,30 @@
+package jolie.lang.parse.ast.expression;
+
+import com.google.common.primitives.UnsignedInteger;
+
+public sealed interface PathOperation {
+
+	// .field
+	record Field(String name) implements PathOperation {
+	}
+
+	// .*
+	record FieldWildcard() implements PathOperation {
+	}
+
+	// [n]
+	record ArrayIndex(UnsignedInteger index) implements PathOperation {
+	}
+
+	// [*]
+	record ArrayWildcard() implements PathOperation {
+	}
+
+	// ..field
+	record RecursiveField(String name) implements PathOperation {
+	}
+
+	// ..*
+	record RecursiveWildcard() implements PathOperation {
+	}
+}

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/PathsExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/PathsExpressionNode.java
@@ -1,0 +1,38 @@
+package jolie.lang.parse.ast.expression;
+
+import jolie.lang.parse.OLVisitor;
+import jolie.lang.parse.ast.OLSyntaxNode;
+import jolie.lang.parse.context.ParsingContext;
+import java.util.List;
+
+/**
+ * Represents a PATHS expression that returns path strings matching a pattern and filter. Example:
+ * res << paths tree.* where $ > 5 Returns: res.results = ["tree.a", "tree.c"] (paths where value >
+ * 5)
+ */
+public class PathsExpressionNode extends OLSyntaxNode {
+	private final List< PathOperation > operations;
+	private final OLSyntaxNode whereClause;
+
+	public PathsExpressionNode(
+		ParsingContext context,
+		List< PathOperation > operations,
+		OLSyntaxNode whereClause ) {
+		super( context );
+		this.operations = operations;
+		this.whereClause = whereClause;
+	}
+
+	public List< PathOperation > operations() {
+		return operations;
+	}
+
+	public OLSyntaxNode whereClause() {
+		return whereClause;
+	}
+
+	@Override
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
+	}
+}

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/PvalExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/PvalExpressionNode.java
@@ -1,0 +1,37 @@
+package jolie.lang.parse.ast.expression;
+
+import jolie.lang.parse.OLVisitor;
+import jolie.lang.parse.ast.OLSyntaxNode;
+import jolie.lang.parse.context.ParsingContext;
+
+import java.util.List;
+
+/**
+ * Represents a pval expression that dereferences a path value to get a reference to the actual
+ * value. Example: pval(res.results[0]).field The path expression must evaluate to a path type.
+ * Optional path operations can be applied to navigate the result (e.g., .field, [0]).
+ */
+public class PvalExpressionNode extends OLSyntaxNode {
+	private final OLSyntaxNode pathExpression;
+	private final List< PathOperation > pathOps;
+
+	public PvalExpressionNode( ParsingContext context, OLSyntaxNode pathExpression,
+		List< PathOperation > pathOps ) {
+		super( context );
+		this.pathExpression = pathExpression;
+		this.pathOps = pathOps;
+	}
+
+	public OLSyntaxNode pathExpression() {
+		return pathExpression;
+	}
+
+	public List< PathOperation > pathOperations() {
+		return pathOps;
+	}
+
+	@Override
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
+	}
+}

--- a/libjolie/src/main/java/jolie/lang/parse/ast/expression/ValuesExpressionNode.java
+++ b/libjolie/src/main/java/jolie/lang/parse/ast/expression/ValuesExpressionNode.java
@@ -1,0 +1,37 @@
+package jolie.lang.parse.ast.expression;
+
+import jolie.lang.parse.OLVisitor;
+import jolie.lang.parse.ast.OLSyntaxNode;
+import jolie.lang.parse.context.ParsingContext;
+import java.util.List;
+
+/**
+ * Represents a VALUES expression that returns actual values matching a pattern and filter. Example:
+ * res << values tree.* where $ > 5 Returns: res.results = [10, 7] (actual values where value > 5)
+ */
+public class ValuesExpressionNode extends OLSyntaxNode {
+	private final List< PathOperation > operations;
+	private final OLSyntaxNode whereClause;
+
+	public ValuesExpressionNode(
+		ParsingContext context,
+		List< PathOperation > operations,
+		OLSyntaxNode whereClause ) {
+		super( context );
+		this.operations = operations;
+		this.whereClause = whereClause;
+	}
+
+	public List< PathOperation > operations() {
+		return operations;
+	}
+
+	public OLSyntaxNode whereClause() {
+		return whereClause;
+	}
+
+	@Override
+	public < C, R > R accept( OLVisitor< C, R > visitor, C ctx ) {
+		return visitor.visit( this, ctx );
+	}
+}

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
@@ -111,6 +111,7 @@ import jolie.lang.parse.ast.expression.ConstantDoubleExpression;
 import jolie.lang.parse.ast.expression.ConstantIntegerExpression;
 import jolie.lang.parse.ast.expression.ConstantLongExpression;
 import jolie.lang.parse.ast.expression.ConstantStringExpression;
+import jolie.lang.parse.ast.expression.CurrentValueNode;
 import jolie.lang.parse.ast.expression.FreshValueExpressionNode;
 import jolie.lang.parse.ast.expression.IfExpressionNode;
 import jolie.lang.parse.ast.expression.InlineTreeExpressionNode;
@@ -119,9 +120,11 @@ import jolie.lang.parse.ast.expression.InstanceOfExpressionNode;
 import jolie.lang.parse.ast.expression.IsTypeExpressionNode;
 import jolie.lang.parse.ast.expression.NotExpressionNode;
 import jolie.lang.parse.ast.expression.OrConditionNode;
+import jolie.lang.parse.ast.expression.PathsExpressionNode;
 import jolie.lang.parse.ast.expression.ProductExpressionNode;
 import jolie.lang.parse.ast.expression.SolicitResponseExpressionNode;
 import jolie.lang.parse.ast.expression.SumExpressionNode;
+import jolie.lang.parse.ast.expression.ValuesExpressionNode;
 import jolie.lang.parse.ast.expression.VariableExpressionNode;
 import jolie.lang.parse.ast.expression.VoidExpressionNode;
 import jolie.lang.parse.ast.types.TypeChoiceDefinition;
@@ -362,6 +365,15 @@ public class SymbolReferenceResolver {
 
 		@Override
 		public void visit( ConstantStringExpression n ) {}
+
+		@Override
+		public void visit( CurrentValueNode n ) {}
+
+		@Override
+		public void visit( PathsExpressionNode n ) {}
+
+		@Override
+		public void visit( ValuesExpressionNode n ) {}
 
 		@Override
 		public void visit( ProductExpressionNode n ) {

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
@@ -76,6 +76,7 @@ import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
 import jolie.lang.parse.ast.PvalAssignStatement;
+import jolie.lang.parse.ast.PvalDeepCopyStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -382,6 +383,9 @@ public class SymbolReferenceResolver {
 
 		@Override
 		public void visit( PvalAssignStatement n ) {}
+
+		@Override
+		public void visit( PvalDeepCopyStatement n ) {}
 
 		@Override
 		public void visit( ProductExpressionNode n ) {

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
@@ -122,6 +122,7 @@ import jolie.lang.parse.ast.expression.NotExpressionNode;
 import jolie.lang.parse.ast.expression.OrConditionNode;
 import jolie.lang.parse.ast.expression.PathsExpressionNode;
 import jolie.lang.parse.ast.expression.ProductExpressionNode;
+import jolie.lang.parse.ast.expression.PvalExpressionNode;
 import jolie.lang.parse.ast.expression.SolicitResponseExpressionNode;
 import jolie.lang.parse.ast.expression.SumExpressionNode;
 import jolie.lang.parse.ast.expression.ValuesExpressionNode;
@@ -374,6 +375,9 @@ public class SymbolReferenceResolver {
 
 		@Override
 		public void visit( ValuesExpressionNode n ) {}
+
+		@Override
+		public void visit( PvalExpressionNode n ) {}
 
 		@Override
 		public void visit( ProductExpressionNode n ) {

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolReferenceResolver.java
@@ -75,6 +75,7 @@ import jolie.lang.parse.ast.OperationDeclaration;
 import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
+import jolie.lang.parse.ast.PvalAssignStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -378,6 +379,9 @@ public class SymbolReferenceResolver {
 
 		@Override
 		public void visit( PvalExpressionNode n ) {}
+
+		@Override
+		public void visit( PvalAssignStatement n ) {}
 
 		@Override
 		public void visit( ProductExpressionNode n ) {

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
@@ -63,6 +63,7 @@ import jolie.lang.parse.ast.OperationDeclaration;
 import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
+import jolie.lang.parse.ast.PvalAssignStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -234,6 +235,9 @@ public class SymbolTableGenerator {
 
 		@Override
 		public void visit( PvalExpressionNode n ) {}
+
+		@Override
+		public void visit( PvalAssignStatement n ) {}
 
 		@Override
 		public void visit( ProductExpressionNode n ) {}

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
@@ -64,6 +64,7 @@ import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
 import jolie.lang.parse.ast.PvalAssignStatement;
+import jolie.lang.parse.ast.PvalDeepCopyStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -238,6 +239,9 @@ public class SymbolTableGenerator {
 
 		@Override
 		public void visit( PvalAssignStatement n ) {}
+
+		@Override
+		public void visit( PvalDeepCopyStatement n ) {}
 
 		@Override
 		public void visit( ProductExpressionNode n ) {}

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
@@ -233,6 +233,9 @@ public class SymbolTableGenerator {
 		public void visit( ValuesExpressionNode n ) {}
 
 		@Override
+		public void visit( PvalExpressionNode n ) {}
+
+		@Override
 		public void visit( ProductExpressionNode n ) {}
 
 		@Override

--- a/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
+++ b/libjolie/src/main/java/jolie/lang/parse/module/SymbolTableGenerator.java
@@ -224,6 +224,15 @@ public class SymbolTableGenerator {
 		public void visit( ConstantStringExpression n ) {}
 
 		@Override
+		public void visit( CurrentValueNode n ) {}
+
+		@Override
+		public void visit( PathsExpressionNode n ) {}
+
+		@Override
+		public void visit( ValuesExpressionNode n ) {}
+
+		@Override
 		public void visit( ProductExpressionNode n ) {}
 
 		@Override

--- a/libjolie/src/main/java/jolie/lang/parse/util/impl/ProgramInspectorCreatorVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/util/impl/ProgramInspectorCreatorVisitor.java
@@ -67,6 +67,7 @@ import jolie.lang.parse.ast.OneWayOperationStatement;
 import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
+import jolie.lang.parse.ast.PvalAssignStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -335,6 +336,9 @@ public class ProgramInspectorCreatorVisitor implements UnitOLVisitor {
 
 	@Override
 	public void visit( PvalExpressionNode n ) {}
+
+	@Override
+	public void visit( PvalAssignStatement n ) {}
 
 	@Override
 	public void visit( ProductExpressionNode n ) {}

--- a/libjolie/src/main/java/jolie/lang/parse/util/impl/ProgramInspectorCreatorVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/util/impl/ProgramInspectorCreatorVisitor.java
@@ -68,6 +68,7 @@ import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
 import jolie.lang.parse.ast.PvalAssignStatement;
+import jolie.lang.parse.ast.PvalDeepCopyStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -339,6 +340,9 @@ public class ProgramInspectorCreatorVisitor implements UnitOLVisitor {
 
 	@Override
 	public void visit( PvalAssignStatement n ) {}
+
+	@Override
+	public void visit( PvalDeepCopyStatement n ) {}
 
 	@Override
 	public void visit( ProductExpressionNode n ) {}

--- a/libjolie/src/main/java/jolie/lang/parse/util/impl/ProgramInspectorCreatorVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/util/impl/ProgramInspectorCreatorVisitor.java
@@ -334,6 +334,9 @@ public class ProgramInspectorCreatorVisitor implements UnitOLVisitor {
 	public void visit( ValuesExpressionNode n ) {}
 
 	@Override
+	public void visit( PvalExpressionNode n ) {}
+
+	@Override
 	public void visit( ProductExpressionNode n ) {}
 
 	@Override

--- a/libjolie/src/main/java/jolie/lang/parse/util/impl/ProgramInspectorCreatorVisitor.java
+++ b/libjolie/src/main/java/jolie/lang/parse/util/impl/ProgramInspectorCreatorVisitor.java
@@ -325,6 +325,15 @@ public class ProgramInspectorCreatorVisitor implements UnitOLVisitor {
 	public void visit( ConstantStringExpression n ) {}
 
 	@Override
+	public void visit( CurrentValueNode n ) {}
+
+	@Override
+	public void visit( PathsExpressionNode n ) {}
+
+	@Override
+	public void visit( ValuesExpressionNode n ) {}
+
+	@Override
 	public void visit( ProductExpressionNode n ) {}
 
 	@Override

--- a/packages/assertions.ol
+++ b/packages/assertions.ol
@@ -35,7 +35,7 @@ RequestResponse:
 service Assertions {
 	execution: concurrent
 
-	embed Values as values
+	embed Values as valuesService
 	embed StringUtils as stringUtils
 	
 	inputPort Input {

--- a/packages/assertions.ol
+++ b/packages/assertions.ol
@@ -49,8 +49,8 @@ service Assertions {
 
 	main {
 		equals( request )() {
-			if( !equals@values( { fst -> request.expected, snd -> request.actual } ) ) {
-				throw( AssertionError, valueToPrettyString@stringUtils(request) ) //, diff@values( request ) )
+			if( !equals@valuesService( { fst -> request.expected, snd -> request.actual } ) ) {
+				throw( AssertionError, valueToPrettyString@stringUtils(request) ) //, diff@valuesService( request ) )
 			}
 		}
 	}

--- a/test/library/companies.json
+++ b/test/library/companies.json
@@ -1,0 +1,680 @@
+{
+    "companies": [
+      {
+        "company": {
+          "name": "TechNova Solutions",
+          "founded": 2012,
+          "headquarters": {
+            "city": "Milano",
+            "country": "Italia",
+            "address": { "street": "Via Roma", "number": 45, "postal_code": "20121" }
+          },
+          "departments": [
+            {
+              "id": "D001",
+              "name": "Ricerca e Sviluppo",
+              "manager": { "name": "Laura Bianchi", "email": "laura.bianchi@technova.it" },
+              "teams": [
+                {
+                  "team_id": "T001",
+                  "team_name": "AI & Machine Learning",
+                  "projects": [
+                    {
+                      "project_id": "P001",
+                      "name": "VisionX",
+                      "status": "in_progress",
+                      "technologies": ["Python", "TensorFlow", "OpenCV"]
+                    },
+                    {
+                      "project_id": "P002",
+                      "name": "Predictify",
+                      "status": "planning",
+                      "technologies": ["Python", "scikit-learn", "Pandas"]
+                    }
+                  ]
+                },
+                {
+                  "team_id": "T002",
+                  "team_name": "Computer Vision",
+                  "projects": [
+                    {
+                      "project_id": "P003",
+                      "name": "EyeTrack",
+                      "status": "testing",
+                      "technologies": ["C++", "OpenCV", "PyTorch"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "D002",
+              "name": "IT Operations",
+              "manager": { "name": "Giovanni Serra", "email": "giovanni.serra@technova.it" },
+              "teams": [
+                {
+                  "team_id": "T003",
+                  "team_name": "Cloud Infrastructure",
+                  "projects": [
+                    {
+                      "project_id": "P004",
+                      "name": "CloudShift",
+                      "status": "completed",
+                      "technologies": ["AWS", "Terraform", "Kubernetes"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "company": {
+          "name": "GreenPulse Energy",
+          "founded": 2015,
+          "headquarters": {
+            "city": "Torino",
+            "country": "Italia",
+            "address": { "street": "Corso Vittorio Emanuele II", "number": 110, "postal_code": "10138" }
+          },
+          "departments": [
+            {
+              "id": "D010",
+              "name": "Ingegneria Energetica",
+              "manager": { "name": "Giulia Conti", "email": "giulia.conti@greenpulse.it" },
+              "teams": [
+                {
+                  "team_id": "T100",
+                  "team_name": "Solare e Fotovoltaico",
+                  "projects": [
+                    {
+                      "project_id": "P100",
+                      "name": "SolarEdge",
+                      "status": "completed",
+                      "technologies": ["MATLAB", "Python", "LabVIEW"]
+                    },
+                    {
+                      "project_id": "P101",
+                      "name": "SunFlow",
+                      "status": "in_progress",
+                      "technologies": ["Java", "Spring Boot", "PostgreSQL"]
+                    }
+                  ]
+                },
+                {
+                  "team_id": "T101",
+                  "team_name": "Eolico",
+                  "projects": [
+                    {
+                      "project_id": "P102",
+                      "name": "WindScope",
+                      "status": "planning",
+                      "technologies": ["C#", ".NET", "Azure"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "D011",
+              "name": "Sostenibilità e Innovazione",
+              "manager": { "name": "Enrico Pellegrini", "email": "enrico.pellegrini@greenpulse.it" },
+              "teams": [
+                {
+                  "team_id": "T102",
+                  "team_name": "Green Analytics",
+                  "projects": [
+                    {
+                      "project_id": "P103",
+                      "name": "CarbonWatch",
+                      "status": "planning",
+                      "technologies": ["R", "Shiny", "Tableau"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "company": {
+          "name": "MediArt Studio",
+          "founded": 2008,
+          "headquarters": {
+            "city": "Firenze",
+            "country": "Italia",
+            "address": { "street": "Via dei Bardi", "number": 9, "postal_code": "50125" }
+          },
+          "departments": [
+            {
+              "id": "D020",
+              "name": "Produzione Multimediale",
+              "manager": { "name": "Stefano Mancini", "email": "stefano.mancini@mediart.it" },
+              "teams": [
+                {
+                  "team_id": "T200",
+                  "team_name": "Video & Animazione",
+                  "projects": [
+                    {
+                      "project_id": "P200",
+                      "name": "Arte360",
+                      "status": "planning",
+                      "technologies": ["After Effects", "Blender", "Unity"]
+                    },
+                    {
+                      "project_id": "P201",
+                      "name": "CulturaXR",
+                      "status": "completed",
+                      "technologies": ["Unreal Engine", "Blender", "DaVinci Resolve"]
+                    }
+                  ]
+                },
+                {
+                  "team_id": "T201",
+                  "team_name": "Post-produzione",
+                  "projects": []
+                }
+              ]
+            },
+            {
+              "id": "D021",
+              "name": "Design",
+              "manager": { "name": "Martina Bellini", "email": "martina.bellini@mediart.it" },
+              "teams": [
+                {
+                  "team_id": "T202",
+                  "team_name": "Grafica 3D",
+                  "projects": [
+                    {
+                      "project_id": "P202",
+                      "name": "RenderFlow",
+                      "status": "in_progress",
+                      "technologies": ["Cinema 4D", "Substance 3D", "Python"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "company": {
+          "name": "AquaPure Technologies",
+          "founded": 2010,
+          "headquarters": {
+            "city": "Genova",
+            "country": "Italia",
+            "address": { "street": "Via San Lorenzo", "number": 67, "postal_code": "16123" }
+          },
+          "departments": [
+            {
+              "id": "D030",
+              "name": "Ricerca Ambientale",
+              "manager": { "name": "Marta Greco", "email": "marta.greco@aquapure.it" },
+              "teams": [
+                {
+                  "team_id": "T300",
+                  "team_name": "Trattamento Acque",
+                  "projects": [
+                    {
+                      "project_id": "P300",
+                      "name": "BlueFilter",
+                      "status": "in_progress",
+                      "technologies": ["C++", "IoT", "AWS IoT Core"]
+                    },
+                    {
+                      "project_id": "P301",
+                      "name": "SmartFlow",
+                      "status": "planning",
+                      "technologies": ["Rust", "gRPC", "Kubernetes"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "D031",
+              "name": "Ingegneria Chimica",
+              "manager": { "name": "Andrea Neri", "email": "andrea.neri@aquapure.it" },
+              "teams": [
+                {
+                  "team_id": "T301",
+                  "team_name": "Analisi Materiali",
+                  "projects": []
+                },
+                {
+                  "team_id": "T302",
+                  "team_name": "Sistemi di Controllo",
+                  "projects": [
+                    {
+                      "project_id": "P302",
+                      "name": "HydroMonitor",
+                      "status": "testing",
+                      "technologies": ["PLC", "OPC UA", "Python"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "company": {
+          "name": "Skyline Drones",
+          "founded": 2016,
+          "headquarters": {
+            "city": "Bologna",
+            "country": "Italia",
+            "address": { "street": "Via Indipendenza", "number": 155, "postal_code": "40121" }
+          },
+          "departments": [
+            {
+              "id": "D040",
+              "name": "Sistemi Aerei",
+              "manager": { "name": "Federico Riva", "email": "federico.riva@skylinedrones.it" },
+              "teams": [
+                {
+                  "team_id": "T400",
+                  "team_name": "Controllo Volo",
+                  "projects": [
+                    {
+                      "project_id": "P400",
+                      "name": "DronePilot AI",
+                      "status": "testing",
+                      "technologies": ["ROS2", "C++", "PX4"]
+                    }
+                  ]
+                },
+                {
+                  "team_id": "T401",
+                  "team_name": "Sensori e Navigazione",
+                  "projects": [
+                    {
+                      "project_id": "P401",
+                      "name": "NavSense",
+                      "status": "planning",
+                      "technologies": ["Kalman Filter", "NumPy", "GNSS RTK"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "D041",
+              "name": "Servizi Aerei",
+              "manager": { "name": "Elisa Gallo", "email": "elisa.gallo@skylinedrones.it" },
+              "teams": [
+                {
+                  "team_id": "T402",
+                  "team_name": "Ispezioni Industriali",
+                  "projects": []
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "company": {
+          "name": "DataWave Analytics",
+          "founded": 2013,
+          "headquarters": {
+            "city": "Roma",
+            "country": "Italia",
+            "address": { "street": "Via Appia Nuova", "number": 240, "postal_code": "00179" }
+          },
+          "departments": [
+            {
+              "id": "D050",
+              "name": "Analisi Dati",
+              "manager": { "name": "Chiara Leone", "email": "chiara.leone@datawave.it" },
+              "teams": [
+                {
+                  "team_id": "T500",
+                  "team_name": "Big Data",
+                  "projects": [
+                    {
+                      "project_id": "P500",
+                      "name": "StreamInsight",
+                      "status": "in_progress",
+                      "technologies": ["Scala", "Kafka", "Spark"]
+                    },
+                    {
+                      "project_id": "P501",
+                      "name": "RealMetrics",
+                      "status": "completed",
+                      "technologies": ["Go", "Flink", "ClickHouse"]
+                    }
+                  ]
+                },
+                {
+                  "team_id": "T501",
+                  "team_name": "Data Governance",
+                  "projects": []
+                }
+              ]
+            },
+            {
+              "id": "D051",
+              "name": "Data Platform",
+              "manager": { "name": "Simone Ferretti", "email": "simone.ferretti@datawave.it" },
+              "teams": [
+                {
+                  "team_id": "T502",
+                  "team_name": "MLOps",
+                  "projects": [
+                    {
+                      "project_id": "P502",
+                      "name": "ModelRail",
+                      "status": "planning",
+                      "technologies": ["MLflow", "Docker", "Argo Workflows"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "company": {
+          "name": "AgriNext Systems",
+          "founded": 2011,
+          "headquarters": {
+            "city": "Parma",
+            "country": "Italia",
+            "address": { "street": "Via Garibaldi", "number": 32, "postal_code": "43121" }
+          },
+          "departments": [
+            {
+              "id": "D060",
+              "name": "Tecnologie Agricole",
+              "manager": { "name": "Paolo Vitale", "email": "paolo.vitale@agrinext.it" },
+              "teams": [
+                {
+                  "team_id": "T600",
+                  "team_name": "Smart Farming",
+                  "projects": [
+                    {
+                      "project_id": "P600",
+                      "name": "CropSense",
+                      "status": "in_progress",
+                      "technologies": ["Python", "IoT", "Django"]
+                    }
+                  ]
+                },
+                {
+                  "team_id": "T601",
+                  "team_name": "Droni Agricoli",
+                  "projects": [
+                    {
+                      "project_id": "P601",
+                      "name": "FieldScan",
+                      "status": "testing",
+                      "technologies": ["ROS", "OpenCV", "Edge TPU"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "D061",
+              "name": "Supply Chain",
+              "manager": { "name": "Valentina Costa", "email": "valentina.costa@agrinext.it" },
+              "teams": [
+                {
+                  "team_id": "T602",
+                  "team_name": "Tracciabilità",
+                  "projects": [
+                    {
+                      "project_id": "P602",
+                      "name": "FarmTrace",
+                      "status": "planning",
+                      "technologies": ["Node.js", "Express", "MongoDB"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "company": {
+          "name": "MedCare Robotics",
+          "founded": 2017,
+          "headquarters": {
+            "city": "Torino",
+            "country": "Italia",
+            "address": { "street": "Via Po", "number": 12, "postal_code": "10123" }
+          },
+          "departments": [
+            {
+              "id": "D070",
+              "name": "Robotica Medica",
+              "manager": { "name": "Serena D’Amato", "email": "serena.damato@medcare.it" },
+              "teams": [
+                {
+                  "team_id": "T700",
+                  "team_name": "Protesi Intelligenti",
+                  "projects": [
+                    {
+                      "project_id": "P700",
+                      "name": "HandMotion",
+                      "status": "testing",
+                      "technologies": ["C#", "Embedded C", "TensorFlow Lite"]
+                    },
+                    {
+                      "project_id": "P701",
+                      "name": "JointFlex",
+                      "status": "planning",
+                      "technologies": ["MATLAB", "Simulink", "CAN Bus"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "D071",
+              "name": "Assistenza Robotica",
+              "manager": { "name": "Giorgio Lupi", "email": "giorgio.lupi@medcare.it" },
+              "teams": [
+                {
+                  "team_id": "T701",
+                  "team_name": "Interfacce Utente",
+                  "projects": [
+                    {
+                      "project_id": "P702",
+                      "name": "CareUI",
+                      "status": "in_progress",
+                      "technologies": ["React", "TypeScript", "GraphQL"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "company": {
+          "name": "NextMove Mobility",
+          "founded": 2014,
+          "headquarters": {
+            "city": "Verona",
+            "country": "Italia",
+            "address": { "street": "Via Mazzini", "number": 77, "postal_code": "37121" }
+          },
+          "departments": [
+            {
+              "id": "D080",
+              "name": "Veicoli Elettrici",
+              "manager": { "name": "Luca Moretti", "email": "luca.moretti@nextmove.it" },
+              "teams": [
+                {
+                  "team_id": "T800",
+                  "team_name": "Motori e Batterie",
+                  "projects": [
+                    {
+                      "project_id": "P800",
+                      "name": "EcoDrive",
+                      "status": "completed",
+                      "technologies": ["C++", "MATLAB", "CAN Bus"]
+                    }
+                  ]
+                },
+                {
+                  "team_id": "T801",
+                  "team_name": "Sistemi di Guida",
+                  "projects": [
+                    {
+                      "project_id": "P801",
+                      "name": "AutoPilotX",
+                      "status": "in_progress",
+                      "technologies": ["Python", "ROS2", "CUDA"]
+                    },
+                    {
+                      "project_id": "P802",
+                      "name": "LaneGuard",
+                      "status": "planning",
+                      "technologies": ["OpenCV", "PyTorch", "ONNX"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "D081",
+              "name": "Connettività",
+              "manager": { "name": "Irene Ferri", "email": "irene.ferri@nextmove.it" },
+              "teams": [
+                {
+                  "team_id": "T802",
+                  "team_name": "Telemetria",
+                  "projects": []
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "company": {
+          "name": "EduSphere Learning",
+          "founded": 2018,
+          "headquarters": {
+            "city": "Napoli",
+            "country": "Italia",
+            "address": { "street": "Via Toledo", "number": 101, "postal_code": "80134" }
+          },
+          "departments": [
+            {
+              "id": "D090",
+              "name": "Formazione Digitale",
+              "manager": { "name": "Francesca Romano", "email": "francesca.romano@edusphere.it" },
+              "teams": [
+                {
+                  "team_id": "T900",
+                  "team_name": "E-learning Platform",
+                  "projects": [
+                    {
+                      "project_id": "P900",
+                      "name": "Learnify",
+                      "status": "in_progress",
+                      "technologies": ["React", "Node.js", "PostgreSQL"]
+                    },
+                    {
+                      "project_id": "P901",
+                      "name": "QuizMaster",
+                      "status": "completed",
+                      "technologies": ["Go", "gRPC", "Redis"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "D091",
+              "name": "Contenuti Educativi",
+              "manager": { "name": "Gabriele Neri", "email": "gabriele.neri@edusphere.it" },
+              "teams": [
+                {
+                  "team_id": "T901",
+                  "team_name": "Didattica Interattiva",
+                  "projects": []
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "company": {
+          "name": "CivicCity Services",
+          "founded": 2009,
+          "headquarters": {
+            "city": "Trieste",
+            "country": "Italia",
+            "address": { "street": "Piazza Unità d'Italia", "number": 4, "postal_code": "34121" }
+          },
+          "departments": [
+            {
+              "id": "D100",
+              "name": "Smart City",
+              "manager": { "name": "Alessio Pagani", "email": "alessio.pagani@civiccity.it" },
+              "teams": [
+                {
+                  "team_id": "T1000",
+                  "team_name": "Mobilità Urbana",
+                  "projects": [
+                    {
+                      "project_id": "P1000",
+                      "name": "ParkSmart",
+                      "status": "completed",
+                      "technologies": ["Kotlin", "Android", "Firebase"]
+                    }
+                  ]
+                },
+                {
+                  "team_id": "T1001",
+                  "team_name": "Illuminazione Intelligente",
+                  "projects": [
+                    {
+                      "project_id": "P1001",
+                      "name": "LightSense",
+                      "status": "in_progress",
+                      "technologies": ["LoRaWAN", "Node-RED", "InfluxDB"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "D101",
+              "name": "Servizi al Cittadino",
+              "manager": { "name": "Rita Donadi", "email": "rita.donadi@civiccity.it" },
+              "teams": [
+                {
+                  "team_id": "T1002",
+                  "team_name": "Sportello Digitale",
+                  "projects": [
+                    {
+                      "project_id": "P1002",
+                      "name": "OpenDesk",
+                      "status": "planning",
+                      "technologies": ["Vue.js", "PHP", "MySQL"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+  

--- a/test/library/paths_values.ol
+++ b/test/library/paths_values.ol
@@ -1,0 +1,131 @@
+from ..test-unit import TestUnitInterface
+from file import File
+
+service Main {
+
+	embed File as File
+
+	inputPort TestUnitInput {
+		location: "local"
+		interfaces: TestUnitInterface
+	}
+
+	init {
+		readFile@File( { filename = "library/companies.json", format = "json" } )( data )
+	}
+
+	define testPathsCompaniesFoundedAfter2014
+	{
+		undef( result );
+		result << paths data.companies[*] where $.company.founded > 2014;
+
+		if ( #result.results != 4 ) {
+			throw( TestFailed, "Expected 4 companies founded after 2014, got " + #result.results )
+		}
+	}
+
+	define testValuesCompanyNames
+	{
+		undef( result );
+		result << values data.companies[*].company where $.founded > 2014;
+
+		if ( #result.results != 4 ) {
+			throw( TestFailed, "Expected 4 companies founded after 2014, got " + #result.results )
+		};
+		// Verify we got company objects with name field
+		if ( result.results[0].name != "GreenPulse Energy" ) {
+			throw( TestFailed, "Expected GreenPulse Energy, got " + result.results[0].name )
+		}
+	}
+
+	define testRecursiveFieldProjects
+	{
+		undef( result );
+		// Find all projects with status "testing" using recursive field
+		result << paths data..projects[*] where $.status == "testing";
+
+		if ( #result.results != 5 ) {
+			throw( TestFailed, "Expected 5 testing projects, got " + #result.results )
+		}
+	}
+
+	define testArrayWildcardWithDollar
+	{
+		undef( result );
+		// Find companies where any project uses "Python"
+		result << paths data.companies[*].company where $..technologies[*] == "Python";
+
+		if ( #result.results != 6 ) {
+			throw( TestFailed, "Expected 6 companies using Python, got " + #result.results )
+		}
+	}
+
+	define testHasOperatorOnDepartments
+	{
+		undef( result );
+		// Find all teams that have projects
+		result << paths data..teams[*] where $ has "projects";
+
+		if ( #result.results != 31 ) {
+			throw( TestFailed, "Expected 31 teams with projects field, got " + #result.results )
+		}
+	}
+
+	define testAllCompanies
+	{
+		undef( result );
+		// Get all companies without filter - should be 11
+		result << paths data.companies[*].company where $.founded > 0;
+
+		if ( #result.results != 11 ) {
+			throw( TestFailed, "Expected 11 total companies, got " + #result.results )
+		}
+	}
+
+	define testSimpleFoundedFilter
+	{
+		undef( result );
+		// Test simple founded filter on same path
+		result << paths data.companies[*].company where $.founded == 2012;
+
+		if ( #result.results != 1 ) {
+			throw( TestFailed, "Expected 1 company founded in 2012, got " + #result.results )
+		}
+	}
+
+	define testSimpleCityFilter
+	{
+		undef( result );
+		// Test simple city filter
+		result << paths data.companies[*].company where $.headquarters.city == "Milano";
+
+		if ( #result.results != 1 ) {
+			throw( TestFailed, "Expected 1 Milano company, got " + #result.results )
+		}
+	}
+
+	define testComplexAndCondition
+	{
+		undef( result );
+		// Find companies in Milano or Torino founded after 2010
+		result << paths data.companies[*].company where ($.headquarters.city == "Milano" || $.headquarters.city == "Torino") && $.founded > 2010;
+
+		if ( #result.results != 3 ) {
+			throw( TestFailed, "Expected 3 companies, got " + #result.results )
+		}
+	}
+
+	main {
+		test()() {
+			testPathsCompaniesFoundedAfter2014;
+			testValuesCompanyNames;
+			testRecursiveFieldProjects;
+			testArrayWildcardWithDollar;
+			testHasOperatorOnDepartments;
+			testAllCompanies;
+			testSimpleFoundedFilter;
+			testSimpleCityFilter;
+			testComplexAndCondition
+		}
+	}
+}

--- a/test/library/values.ol
+++ b/test/library/values.ol
@@ -25,7 +25,7 @@ from console import Console
 	A template for test units.
 */
 service Main {
-	embed Values as values
+	embed Values as valuesService
 	embed Console as console
 
 	inputPort TestUnitInput {
@@ -41,21 +41,21 @@ service Main {
 				interests[0] = "beer"
 				interests[1] = "hockey"
 			}
-			if( !equals@values( {
+			if( !equals@valuesService( {
 				fst << person
 				snd << person
 			} ) ) {
 				throw( TestFailed, "value equality does not match expected result" )
 			}
 
-			if( !equals@values( {
+			if( !equals@valuesService( {
 				fst -> person
 				snd << person
 			} ) ) {
 				throw( TestFailed, "value equality does not match expected result" )
 			}
 
-			if( equals@values( {
+			if( equals@valuesService( {
 				fst << person
 				snd << {
 					name = "Homer"
@@ -66,7 +66,7 @@ service Main {
 				throw( TestFailed, "value equality does not match expected result" )
 			}
 
-			if( equals@values( {
+			if( equals@valuesService( {
 				fst << person
 				snd << {
 					name = "Homer"
@@ -78,21 +78,21 @@ service Main {
 				throw( TestFailed, "value equality does not match expected result" )
 			}
 
-			if( hashCode@values( void ) != 0 ) {
+			if( hashCode@valuesService( void ) != 0 ) {
 			 	throw( TestFailed, "value hashCode does not match expected result" )
 			}
 
-			if( hashCode@values( person ) != hashCode@values( person ) ) {
+			if( hashCode@valuesService( person ) != hashCode@valuesService( person ) ) {
 			 	throw( TestFailed, "value hashCode does not match expected result" )
 			}
 
 			person2 -> person
-			if( hashCode@values( person ) != hashCode@values( person2 ) ) {
+			if( hashCode@valuesService( person ) != hashCode@valuesService( person2 ) ) {
 			 	throw( TestFailed, "value hashCode does not match expected result" )
 			}
 
 			person3 << person
-			if( hashCode@values( person ) != hashCode@values( person3 ) ) {
+			if( hashCode@valuesService( person ) != hashCode@valuesService( person3 ) ) {
 			 	throw( TestFailed, "value hashCode does not match expected result" )
 			}
 		}

--- a/test/primitives/paths_values.ol
+++ b/test/primitives/paths_values.ol
@@ -65,9 +65,65 @@ define testNestedFieldAccess
 	}
 }
 
+define testPval
+{
+	// Setup test data with children
+	mydata[0] = 100;
+	mydata[0].child = "zero";
+	mydata[1] = 200;
+	mydata[1].child = "one";
+	mydata[2] = 300;
+	mydata[2].child = "two";
+
+	// Get paths to elements > 150
+	res << paths mydata[*] where $ > 150;
+
+	if ( #res.results != 2 ) {
+		throw( TestFailed, "Expected 2 paths, got " + #res.results )
+	};
+
+	// Test pval as rvalue (reading root value)
+	readVal = pval(res.results[0]);
+	if ( readVal != 200 ) {
+		throw( TestFailed, "Expected pval(res.results[0]) to return 200, got " + readVal )
+	};
+
+	// Test pval with path navigation - pval(x).child
+	childVal = pval(res.results[0]).child;
+	if ( childVal != "one" ) {
+		throw( TestFailed, "Expected pval(res.results[0]).child to be 'one', got '" + childVal + "'" )
+	};
+
+	childVal2 = pval(res.results[1]).child;
+	if ( childVal2 != "two" ) {
+		throw( TestFailed, "Expected pval(res.results[1]).child to be 'two', got '" + childVal2 + "'" )
+	};
+
+	// Test pval with array indexing - pval(x).children[n]
+	mydata[1].children[0] = "first";
+	mydata[1].children[1] = "second";
+	mydata[1].children[2] = "third";
+
+	arrayVal = pval(res.results[0]).children[1];
+	if ( arrayVal != "second" ) {
+		throw( TestFailed, "Expected pval(res.results[0]).children[1] to be 'second', got '" + arrayVal + "'" )
+	};
+
+	// Test pval with composite path - pval(x).a.b[n].c
+	mydata[1].nested.items[0].name = "item0";
+	mydata[1].nested.items[1].name = "item1";
+	mydata[1].nested.items[2].name = "item2";
+
+	compositeVal = pval(res.results[0]).nested.items[1].name;
+	if ( compositeVal != "item1" ) {
+		throw( TestFailed, "Expected pval(res.results[0]).nested.items[1].name to be 'item1', got '" + compositeVal + "'" )
+	}
+}
+
 define doTest
 {
 	testPathsBasic;
 	testPathType;
-	testNestedFieldAccess
+	testNestedFieldAccess;
+	testPval
 }

--- a/test/primitives/paths_values.ol
+++ b/test/primitives/paths_values.ol
@@ -1,0 +1,34 @@
+include "../AbstractTestUnit.iol"
+
+define testPathsBasic
+{
+	data[0] = 10;
+	data[1] = 20;
+	data[2] = 30;
+
+	result << paths data[*] where $ > 15;
+
+	if ( #result.results != 2 ) {
+		throw( TestFailed, "Expected 2 results, got " + #result.results )
+	}
+}
+
+define testNestedFieldAccess
+{
+	root.items[0].value = 5;
+	root.items[1].value = 15;
+	root.items[2].value = 25;
+
+	// Test navigation to items[*].value
+	result << paths root.items[*].value where $ > 10;
+
+	if ( #result.results != 2 ) {
+		throw( TestFailed, "Expected 2 items with value>10, got " + #result.results )
+	}
+}
+
+define doTest
+{
+	testPathsBasic;
+	testNestedFieldAccess
+}

--- a/test/primitives/paths_values.ol
+++ b/test/primitives/paths_values.ol
@@ -1,5 +1,9 @@
 include "../AbstractTestUnit.iol"
 
+type PathResult {
+	results[0,*]: path
+}
+
 define testPathsBasic
 {
 	data[0] = 10;
@@ -10,6 +14,40 @@ define testPathsBasic
 
 	if ( #result.results != 2 ) {
 		throw( TestFailed, "Expected 2 results, got " + #result.results )
+	}
+}
+
+define testPathType
+{
+	data[0] = 100;
+	data[1] = 200;
+	data[2] = 300;
+
+	result << paths data[*] where $ > 150;
+
+	// Verify we get path type values
+	if ( #result.results != 2 ) {
+		throw( TestFailed, "Expected 2 path results, got " + #result.results )
+	};
+
+	// Verify path values are of type path using instanceof
+	if ( !(result.results[0] instanceof path) ) {
+		throw( TestFailed, "Expected result.results[0] to be instanceof path" )
+	};
+
+	if ( !(result.results[1] instanceof path) ) {
+		throw( TestFailed, "Expected result.results[1] to be instanceof path" )
+	};
+
+	// Verify path values can be converted to string
+	pathStr = "" + result.results[0];
+	if ( pathStr != "data[1]" ) {
+		throw( TestFailed, "Expected path 'data[1]', got '" + pathStr + "'" )
+	};
+
+	// Verify result matches PathResult type structure
+	if ( !(result instanceof PathResult) ) {
+		throw( TestFailed, "Expected result to be instanceof PathResult" )
 	}
 }
 
@@ -30,5 +68,6 @@ define testNestedFieldAccess
 define doTest
 {
 	testPathsBasic;
+	testPathType;
 	testNestedFieldAccess
 }

--- a/tools/jolie2plasma/src/main/java/joliex/plasma/impl/InterfaceVisitor.java
+++ b/tools/jolie2plasma/src/main/java/joliex/plasma/impl/InterfaceVisitor.java
@@ -388,4 +388,7 @@ public class InterfaceVisitor implements UnitOLVisitor {
 
 	@Override
 	public void visit( ValuesExpressionNode n ) {}
+
+	@Override
+	public void visit( PvalExpressionNode n ) {}
 }

--- a/tools/jolie2plasma/src/main/java/joliex/plasma/impl/InterfaceVisitor.java
+++ b/tools/jolie2plasma/src/main/java/joliex/plasma/impl/InterfaceVisitor.java
@@ -62,6 +62,7 @@ import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
 import jolie.lang.parse.ast.PvalAssignStatement;
+import jolie.lang.parse.ast.PvalDeepCopyStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -395,4 +396,7 @@ public class InterfaceVisitor implements UnitOLVisitor {
 
 	@Override
 	public void visit( PvalAssignStatement n ) {}
+
+	@Override
+	public void visit( PvalDeepCopyStatement n ) {}
 }

--- a/tools/jolie2plasma/src/main/java/joliex/plasma/impl/InterfaceVisitor.java
+++ b/tools/jolie2plasma/src/main/java/joliex/plasma/impl/InterfaceVisitor.java
@@ -61,6 +61,7 @@ import jolie.lang.parse.ast.OneWayOperationStatement;
 import jolie.lang.parse.ast.OutputPortInfo;
 import jolie.lang.parse.ast.ParallelStatement;
 import jolie.lang.parse.ast.PointerStatement;
+import jolie.lang.parse.ast.PvalAssignStatement;
 import jolie.lang.parse.ast.PostDecrementStatement;
 import jolie.lang.parse.ast.PostIncrementStatement;
 import jolie.lang.parse.ast.PreDecrementStatement;
@@ -391,4 +392,7 @@ public class InterfaceVisitor implements UnitOLVisitor {
 
 	@Override
 	public void visit( PvalExpressionNode n ) {}
+
+	@Override
+	public void visit( PvalAssignStatement n ) {}
 }

--- a/tools/jolie2plasma/src/main/java/joliex/plasma/impl/InterfaceVisitor.java
+++ b/tools/jolie2plasma/src/main/java/joliex/plasma/impl/InterfaceVisitor.java
@@ -379,4 +379,13 @@ public class InterfaceVisitor implements UnitOLVisitor {
 
 	@Override
 	public void visit( IfExpressionNode n ) {}
+
+	@Override
+	public void visit( CurrentValueNode n ) {}
+
+	@Override
+	public void visit( PathsExpressionNode n ) {}
+
+	@Override
+	public void visit( ValuesExpressionNode n ) {}
 }


### PR DESCRIPTION
Implements PATHS and VALUES expressions for querying data structures:
- paths data[*] where $ > 5 → returns matching paths
- values data[*] where $ > 5 → returns matching values
- $ with composable path navigation: $.*[*], $..field, $[n], $[*]
- HAS operator: where $ has "field" checks field existence
- Existential semantics: ANY value matches (∃), not all

Example: paths tree..field[*].*[4] where $.field2[*].*[*] has "field3"

Key components:
- PathsExpression/ValuesExpression (runtime evaluation)
- CurrentValueExpression ($ with path operations)
- WhereEvaluator (existential WHERE clause evaluation)
- ValueNavigator (tree traversal with path operations)
- PathOperation sealed interface (6 composable operation types)
- Candidate record (vector + index + path for navigation)
